### PR TITLE
ルーティン一覧画面

### DIFF
--- a/lib/feature/routine/state/routine.dart
+++ b/lib/feature/routine/state/routine.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:isar/isar.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -6,16 +7,22 @@ import '../data/routine.dart';
 
 part 'routine.g.dart';
 
+extension RoutineX on Routine {
+  TimeOfDay get notificationTimeOfDay => TimeOfDay(
+        hour: notificationTime ~/ 3600,
+        minute: notificationTime % 60,
+      );
+}
+
 @riverpod
 Stream<List<Routine>> routines(RoutinesRef ref) {
   final isar = ref.watch(isarProvider);
 
   // 本来は無限スクロール対応などして部分取得したほうがパフォーマンス的に望ましいが
   // 現状は全件取得して表示している。
-  // WHERE state = true ORDER BY createdAt DESC
+  // ORDER BY createdAt DESC
   return isar.routines
-      .filter()
-      .stateEqualTo(true)
+      .where()
       .sortByCreatedAtDesc()
       .watch(fireImmediately: true);
 }

--- a/lib/feature/routine/state/routine.g.dart
+++ b/lib/feature/routine/state/routine.g.dart
@@ -6,7 +6,7 @@ part of 'routine.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$routinesHash() => r'126c4a79ad47d2aba423081792db0be363e365bb';
+String _$routinesHash() => r'6e3ef16d453e1e9f2f95097039302f7efc440f0e';
 
 /// See also [routines].
 @ProviderFor(routines)

--- a/lib/feature/routine/ui/routine_index_page.dart
+++ b/lib/feature/routine/ui/routine_index_page.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/ui/component/material.dart';
 import '../../../core/ui/component/riverpod.dart';
 import '../data/routine.dart';
 import '../state/routine.dart';
+import '../use_case/update_routine.dart';
 import 'component/navigate_routine_add_page.dart';
 
 class RoutineIndexPage extends StatelessWidget {
@@ -13,7 +15,7 @@ class RoutineIndexPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('ルーティン一覧'),
+        title: const Text('ルーティン'),
         actions: const [
           NavigateRoutineAddPageButton(),
         ],
@@ -35,16 +37,22 @@ class _Body extends ConsumerWidget {
     final asyncValue = ref.watch(routinesProvider);
     return asyncValue.whenWidget(
       data: (routines) {
-        return ListView.builder(
+        if (routines.isEmpty) {
+          return const Center(
+            child: Text('ルーティンがありません'),
+          );
+        }
+        return ListView.separated(
           itemCount: routines.length,
           itemBuilder: (context, index) => _ListTile(routine: routines[index]),
+          separatorBuilder: (context, index) => const _Divider(),
         );
       },
     );
   }
 }
 
-class _ListTile extends StatelessWidget {
+class _ListTile extends ConsumerWidget {
   const _ListTile({
     required this.routine,
   });
@@ -52,12 +60,38 @@ class _ListTile extends StatelessWidget {
   final Routine routine;
 
   @override
-  Widget build(BuildContext context) {
-    // TODO(any): 表示は仮実装
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listenAsync(updateRoutineUseCaseProvider);
     return ListTile(
-      leading: Text(routine.id.toString()),
-      title: Text(routine.notificationTime.toString()),
-      subtitle: Text(routine.createdAt.toString()),
+      onTap: () {
+        // TODO(susa): 編集画面に遷移する
+      },
+      title: Text(
+        routine.notificationTimeOfDay.format(context),
+        style: context.displayMedium?.copyWith(
+          color: routine.state ? null : context.outline,
+        ),
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      trailing: Switch(
+        value: routine.state,
+        onChanged: (value) => ref
+            .read(updateRoutineUseCaseProvider.notifier)
+            .invoke(routine, newState: value),
+      ),
+    );
+  }
+}
+
+class _Divider extends StatelessWidget {
+  const _Divider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Divider(
+      height: 0,
+      indent: 16,
+      endIndent: 16,
     );
   }
 }

--- a/lib/feature/routine/ui/routine_index_page.dart
+++ b/lib/feature/routine/ui/routine_index_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
 
 import '../../../core/ui/component/material.dart';
 import '../../../core/ui/component/riverpod.dart';
 import '../data/routine.dart';
 import '../state/routine.dart';
+import '../use_case/delete_routine.dart';
 import '../use_case/update_routine.dart';
 import 'component/navigate_routine_add_page.dart';
 
@@ -62,22 +64,38 @@ class _ListTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.listenAsync(updateRoutineUseCaseProvider);
-    return ListTile(
-      onTap: () {
-        // TODO(susa): 編集画面に遷移する
-      },
-      title: Text(
-        routine.notificationTimeOfDay.format(context),
-        style: context.displayMedium?.copyWith(
-          color: routine.state ? null : context.outline,
-        ),
+    ref.listenAsync(deleteRoutineUseCaseProvider);
+    return Slidable(
+      endActionPane: ActionPane(
+        motion: const ScrollMotion(),
+        extentRatio: 0.2,
+        children: [
+          SlidableAction(
+            onPressed: (context) =>
+                ref.read(deleteRoutineUseCaseProvider.notifier).invoke(routine),
+            backgroundColor: context.error,
+            foregroundColor: context.onError,
+            label: '削除',
+          ),
+        ],
       ),
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      trailing: Switch(
-        value: routine.state,
-        onChanged: (value) => ref
-            .read(updateRoutineUseCaseProvider.notifier)
-            .invoke(routine, newState: value),
+      child: ListTile(
+        onTap: () {
+          // TODO(susa): 編集画面に遷移する
+        },
+        title: Text(
+          routine.notificationTimeOfDay.format(context),
+          style: context.displayMedium?.copyWith(
+            color: routine.state ? null : context.outline,
+          ),
+        ),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        trailing: Switch(
+          value: routine.state,
+          onChanged: (value) => ref
+              .read(updateRoutineUseCaseProvider.notifier)
+              .invoke(routine, newState: value),
+        ),
       ),
     );
   }
@@ -89,7 +107,7 @@ class _Divider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Divider(
-      height: 0,
+      height: 1,
       indent: 16,
       endIndent: 16,
     );

--- a/lib/feature/routine/use_case/delete_routine.dart
+++ b/lib/feature/routine/use_case/delete_routine.dart
@@ -1,0 +1,25 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/data/isar/isar.dart';
+import '../data/routine.dart';
+
+part 'delete_routine.g.dart';
+
+@riverpod
+class DeleteRoutineUseCase extends _$DeleteRoutineUseCase {
+  @override
+  FutureOr<void> build() => null;
+
+  Future<void> invoke(Routine routine) async {
+    if (state.isLoading) {
+      return;
+    }
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() async {
+      final isar = ref.read(isarProvider);
+      await isar.writeTxn(() async {
+        await isar.routines.delete(routine.id);
+      });
+    });
+  }
+}

--- a/lib/feature/routine/use_case/delete_routine.g.dart
+++ b/lib/feature/routine/use_case/delete_routine.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'delete_routine.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$deleteRoutineUseCaseHash() =>
+    r'df68eec3f0ce003b4ca63ae0f269ca86c4890738';
+
+/// See also [DeleteRoutineUseCase].
+@ProviderFor(DeleteRoutineUseCase)
+final deleteRoutineUseCaseProvider =
+    AutoDisposeAsyncNotifierProvider<DeleteRoutineUseCase, void>.internal(
+  DeleteRoutineUseCase.new,
+  name: r'deleteRoutineUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$deleteRoutineUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$DeleteRoutineUseCase = AutoDisposeAsyncNotifier<void>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/routine/use_case/update_routine.dart
+++ b/lib/feature/routine/use_case/update_routine.dart
@@ -1,0 +1,31 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/data/isar/isar.dart';
+import '../data/routine.dart';
+
+part 'update_routine.g.dart';
+
+@riverpod
+class UpdateRoutineUseCase extends _$UpdateRoutineUseCase {
+  @override
+  FutureOr<void> build() => null;
+
+  Future<void> invoke(
+    Routine routine, {
+    bool? newState,
+  }) async {
+    if (state.isLoading) {
+      return;
+    }
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() async {
+      final isar = ref.read(isarProvider);
+      await isar.writeTxn(() async {
+        if (newState != null) {
+          routine.state = newState;
+        }
+        await isar.routines.put(routine);
+      });
+    });
+  }
+}

--- a/lib/feature/routine/use_case/update_routine.g.dart
+++ b/lib/feature/routine/use_case/update_routine.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'update_routine.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$updateRoutineUseCaseHash() =>
+    r'2a01162fcd05bebdda2e95886dccd7e11388bc71';
+
+/// See also [UpdateRoutineUseCase].
+@ProviderFor(UpdateRoutineUseCase)
+final updateRoutineUseCaseProvider =
+    AutoDisposeAsyncNotifierProvider<UpdateRoutineUseCase, void>.internal(
+  UpdateRoutineUseCase.new,
+  name: r'updateRoutineUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$updateRoutineUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$UpdateRoutineUseCase = AutoDisposeAsyncNotifier<void>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -291,6 +291,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.9"
+  flutter_slidable:
+    dependency: "direct main"
+    description:
+      name: flutter_slidable
+      sha256: "19ed4813003a6ff4e9c6bcce37e792a2a358919d7603b2b31ff200229191e44c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: ^2.4.9
+  flutter_slidable: ^3.0.1
   freezed_annotation: ^2.4.1
   gap: ^3.0.1
   go_router: ^13.0.1


### PR DESCRIPTION
# 関連する Issue

- close #3

# やったこと

- ルーティン一覧画面
  - デザインはiPhoneの時計アプリを真似て最小限にしました。
  - ON/OFFができるようにしました。
  - 削除ができるようにしました。
    - flutter_slidable を導入して、左スワイプで削除ができるようにしました。初めて使ったので勉強になりました！
  - 0件の場合は「ルーティンがありません」を表示するようにしました。

# やらないこと

- なし

# スクリーンショット


https://github.com/IkemotoNanako/repeat_notification_app/assets/13707135/278056d3-58bb-4832-a642-f4ba243c6021


