### PR TITLE
曜日の繰り返し設定の実装前のリファクタリングなど

### DIFF
--- a/lib/feature/routine/state/current_routine.dart
+++ b/lib/feature/routine/state/current_routine.dart
@@ -1,18 +1,42 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/data/isar/isar.dart';
 import '../data/routine.dart';
 
+part 'current_routine.freezed.dart';
 part 'current_routine.g.dart';
 
+@freezed
+class RoutineParams with _$RoutineParams {
+  const factory RoutineParams({
+    required int routineId,
+    required Routine? cache,
+  }) = _RoutineParams;
+}
+
 @Riverpod(dependencies: [])
-int currentRoutineId(CurrentRoutineIdRef ref) {
+RoutineParams currentRoutineParams(CurrentRoutineParamsRef ref) {
   throw UnimplementedError();
 }
 
-@Riverpod(dependencies: [currentRoutineId])
+@Riverpod(dependencies: [currentRoutineParams])
+int currentRoutineId(CurrentRoutineIdRef ref) {
+  final params = ref.watch(currentRoutineParamsProvider);
+  return params.routineId;
+}
+
+@Riverpod(dependencies: [currentRoutineParams])
 FutureOr<Routine?> currentRoutine(CurrentRoutineRef ref) async {
-  final id = ref.watch(currentRoutineIdProvider);
+  final params = ref.watch(currentRoutineParamsProvider);
+  final cache = params.cache;
+  if (cache != null) {
+    // キャッシュがあればキャッシュを返す
+    return cache;
+  }
+
+  // キャッシュがなければデータベースから取得して返す
+  final id = params.routineId;
   final isar = ref.watch(isarProvider);
   return isar.routines.get(id);
 }

--- a/lib/feature/routine/state/current_routine.dart
+++ b/lib/feature/routine/state/current_routine.dart
@@ -27,7 +27,7 @@ int currentRoutineId(CurrentRoutineIdRef ref) {
 }
 
 @Riverpod(dependencies: [currentRoutineParams])
-FutureOr<Routine?> currentRoutine(CurrentRoutineRef ref) async {
+Routine? currentRoutine(CurrentRoutineRef ref) {
   final params = ref.watch(currentRoutineParamsProvider);
   final cache = params.cache;
   if (cache != null) {
@@ -38,5 +38,5 @@ FutureOr<Routine?> currentRoutine(CurrentRoutineRef ref) async {
   // キャッシュがなければデータベースから取得して返す
   final id = params.routineId;
   final isar = ref.watch(isarProvider);
-  return isar.routines.get(id);
+  return isar.routines.getSync(id);
 }

--- a/lib/feature/routine/state/current_routine.freezed.dart
+++ b/lib/feature/routine/state/current_routine.freezed.dart
@@ -1,0 +1,151 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'current_routine.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$RoutineParams {
+  int get routineId => throw _privateConstructorUsedError;
+  Routine? get cache => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $RoutineParamsCopyWith<RoutineParams> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RoutineParamsCopyWith<$Res> {
+  factory $RoutineParamsCopyWith(
+          RoutineParams value, $Res Function(RoutineParams) then) =
+      _$RoutineParamsCopyWithImpl<$Res, RoutineParams>;
+  @useResult
+  $Res call({int routineId, Routine? cache});
+}
+
+/// @nodoc
+class _$RoutineParamsCopyWithImpl<$Res, $Val extends RoutineParams>
+    implements $RoutineParamsCopyWith<$Res> {
+  _$RoutineParamsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? routineId = null,
+    Object? cache = freezed,
+  }) {
+    return _then(_value.copyWith(
+      routineId: null == routineId
+          ? _value.routineId
+          : routineId // ignore: cast_nullable_to_non_nullable
+              as int,
+      cache: freezed == cache
+          ? _value.cache
+          : cache // ignore: cast_nullable_to_non_nullable
+              as Routine?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$RoutineParamsImplCopyWith<$Res>
+    implements $RoutineParamsCopyWith<$Res> {
+  factory _$$RoutineParamsImplCopyWith(
+          _$RoutineParamsImpl value, $Res Function(_$RoutineParamsImpl) then) =
+      __$$RoutineParamsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int routineId, Routine? cache});
+}
+
+/// @nodoc
+class __$$RoutineParamsImplCopyWithImpl<$Res>
+    extends _$RoutineParamsCopyWithImpl<$Res, _$RoutineParamsImpl>
+    implements _$$RoutineParamsImplCopyWith<$Res> {
+  __$$RoutineParamsImplCopyWithImpl(
+      _$RoutineParamsImpl _value, $Res Function(_$RoutineParamsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? routineId = null,
+    Object? cache = freezed,
+  }) {
+    return _then(_$RoutineParamsImpl(
+      routineId: null == routineId
+          ? _value.routineId
+          : routineId // ignore: cast_nullable_to_non_nullable
+              as int,
+      cache: freezed == cache
+          ? _value.cache
+          : cache // ignore: cast_nullable_to_non_nullable
+              as Routine?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$RoutineParamsImpl implements _RoutineParams {
+  const _$RoutineParamsImpl({required this.routineId, required this.cache});
+
+  @override
+  final int routineId;
+  @override
+  final Routine? cache;
+
+  @override
+  String toString() {
+    return 'RoutineParams(routineId: $routineId, cache: $cache)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RoutineParamsImpl &&
+            (identical(other.routineId, routineId) ||
+                other.routineId == routineId) &&
+            (identical(other.cache, cache) || other.cache == cache));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, routineId, cache);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RoutineParamsImplCopyWith<_$RoutineParamsImpl> get copyWith =>
+      __$$RoutineParamsImplCopyWithImpl<_$RoutineParamsImpl>(this, _$identity);
+}
+
+abstract class _RoutineParams implements RoutineParams {
+  const factory _RoutineParams(
+      {required final int routineId,
+      required final Routine? cache}) = _$RoutineParamsImpl;
+
+  @override
+  int get routineId;
+  @override
+  Routine? get cache;
+  @override
+  @JsonKey(ignore: true)
+  _$$RoutineParamsImplCopyWith<_$RoutineParamsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/feature/routine/state/current_routine.g.dart
+++ b/lib/feature/routine/state/current_routine.g.dart
@@ -6,7 +6,24 @@ part of 'current_routine.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$currentRoutineIdHash() => r'a8691b656922f95436bc9d3092557218f22fef11';
+String _$currentRoutineParamsHash() =>
+    r'70c184703c7297c043bf06a8e5624816741cca4f';
+
+/// See also [currentRoutineParams].
+@ProviderFor(currentRoutineParams)
+final currentRoutineParamsProvider =
+    AutoDisposeProvider<RoutineParams>.internal(
+  currentRoutineParams,
+  name: r'currentRoutineParamsProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$currentRoutineParamsHash,
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>{},
+);
+
+typedef CurrentRoutineParamsRef = AutoDisposeProviderRef<RoutineParams>;
+String _$currentRoutineIdHash() => r'c40ba932239fbf6c6ee24b745c3d87c044ad39d4';
 
 /// See also [currentRoutineId].
 @ProviderFor(currentRoutineId)
@@ -16,12 +33,15 @@ final currentRoutineIdProvider = AutoDisposeProvider<int>.internal(
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
       : _$currentRoutineIdHash,
-  dependencies: const <ProviderOrFamily>[],
-  allTransitiveDependencies: const <ProviderOrFamily>{},
+  dependencies: <ProviderOrFamily>[currentRoutineParamsProvider],
+  allTransitiveDependencies: <ProviderOrFamily>{
+    currentRoutineParamsProvider,
+    ...?currentRoutineParamsProvider.allTransitiveDependencies
+  },
 );
 
 typedef CurrentRoutineIdRef = AutoDisposeProviderRef<int>;
-String _$currentRoutineHash() => r'e59cab2d70d814c4c571ce753173347a6470228a';
+String _$currentRoutineHash() => r'8cea908a5ebe6b3ca2110d2cc0106741bd63bf2d';
 
 /// See also [currentRoutine].
 @ProviderFor(currentRoutine)
@@ -31,10 +51,10 @@ final currentRoutineProvider = AutoDisposeFutureProvider<Routine?>.internal(
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
       : _$currentRoutineHash,
-  dependencies: <ProviderOrFamily>[currentRoutineIdProvider],
+  dependencies: <ProviderOrFamily>[currentRoutineParamsProvider],
   allTransitiveDependencies: <ProviderOrFamily>{
-    currentRoutineIdProvider,
-    ...?currentRoutineIdProvider.allTransitiveDependencies
+    currentRoutineParamsProvider,
+    ...?currentRoutineParamsProvider.allTransitiveDependencies
   },
 );
 

--- a/lib/feature/routine/state/current_routine.g.dart
+++ b/lib/feature/routine/state/current_routine.g.dart
@@ -41,11 +41,11 @@ final currentRoutineIdProvider = AutoDisposeProvider<int>.internal(
 );
 
 typedef CurrentRoutineIdRef = AutoDisposeProviderRef<int>;
-String _$currentRoutineHash() => r'8cea908a5ebe6b3ca2110d2cc0106741bd63bf2d';
+String _$currentRoutineHash() => r'f6b1477653f1d9a5bdce02f4f5343c3387e63d55';
 
 /// See also [currentRoutine].
 @ProviderFor(currentRoutine)
-final currentRoutineProvider = AutoDisposeFutureProvider<Routine?>.internal(
+final currentRoutineProvider = AutoDisposeProvider<Routine?>.internal(
   currentRoutine,
   name: r'currentRoutineProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -58,6 +58,6 @@ final currentRoutineProvider = AutoDisposeFutureProvider<Routine?>.internal(
   },
 );
 
-typedef CurrentRoutineRef = AutoDisposeFutureProviderRef<Routine?>;
+typedef CurrentRoutineRef = AutoDisposeProviderRef<Routine?>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/routine/state/routine_form_values.dart
+++ b/lib/feature/routine/state/routine_form_values.dart
@@ -35,12 +35,28 @@ class RoutineFormValues with _$RoutineFormValues {
 
 @riverpod
 class AdditionalRoutineFormValuesNotifier
-    extends _$AdditionalRoutineFormValuesNotifier {
+    extends _$AdditionalRoutineFormValuesNotifier
+    with _RoutineFormValuesNotifier {
   @override
   RoutineFormValues build() {
     return const RoutineFormValues();
   }
+}
 
+@Riverpod(dependencies: [currentRoutine])
+class UpdatedRoutineFormValuesNotifier
+    extends _$UpdatedRoutineFormValuesNotifier with _RoutineFormValuesNotifier {
+  @override
+  RoutineFormValues build() {
+    final routine = ref.watch(currentRoutineProvider);
+    if (routine == null) {
+      throw StateError('Routine is not found');
+    }
+    return RoutineFormValues.fromEntity(routine);
+  }
+}
+
+mixin _RoutineFormValuesNotifier on AutoDisposeNotifier<RoutineFormValues> {
   void updateNotificationTime(TimeOfDay value) {
     state = state.copyWith(notificationTimeOfDay: value);
   }
@@ -53,38 +69,5 @@ class AdditionalRoutineFormValuesNotifier
   // ignore: avoid_positional_boolean_parameters
   void updateEnablePush(bool value) {
     state = state.copyWith(enablePush: value);
-  }
-}
-
-@Riverpod(dependencies: [currentRoutine])
-class UpdatedRoutineFormValuesNotifier
-    extends _$UpdatedRoutineFormValuesNotifier {
-  @override
-  FutureOr<RoutineFormValues> build() async {
-    final routine = await ref.watch(currentRoutineProvider.future);
-    if (routine == null) {
-      throw StateError('Routine is not found');
-    }
-    return RoutineFormValues.fromEntity(routine);
-  }
-
-  void updateNotificationTime(TimeOfDay value) {
-    state = AsyncValue.data(
-      state.requireValue.copyWith(notificationTimeOfDay: value),
-    );
-  }
-
-  // ignore: avoid_positional_boolean_parameters
-  void updateEnableSound(bool value) {
-    state = AsyncValue.data(
-      state.requireValue.copyWith(enableSound: value),
-    );
-  }
-
-  // ignore: avoid_positional_boolean_parameters
-  void updateEnablePush(bool value) {
-    state = AsyncValue.data(
-      state.requireValue.copyWith(enablePush: value),
-    );
   }
 }

--- a/lib/feature/routine/state/routine_form_values.g.dart
+++ b/lib/feature/routine/state/routine_form_values.g.dart
@@ -7,7 +7,7 @@ part of 'routine_form_values.dart';
 // **************************************************************************
 
 String _$additionalRoutineFormValuesNotifierHash() =>
-    r'7f5e078da4e3faf30b8ab26fb3f70afff8729761';
+    r'e3d99c6e32d1791d37028fc88bb67403f052935e';
 
 /// See also [AdditionalRoutineFormValuesNotifier].
 @ProviderFor(AdditionalRoutineFormValuesNotifier)
@@ -25,13 +25,12 @@ final additionalRoutineFormValuesNotifierProvider = AutoDisposeNotifierProvider<
 typedef _$AdditionalRoutineFormValuesNotifier
     = AutoDisposeNotifier<RoutineFormValues>;
 String _$updatedRoutineFormValuesNotifierHash() =>
-    r'1401fa38caa9f0560eb44384f22528234cf23afe';
+    r'e09de582ee283a166ecd0349ea2ad78e9e49ae85';
 
 /// See also [UpdatedRoutineFormValuesNotifier].
 @ProviderFor(UpdatedRoutineFormValuesNotifier)
-final updatedRoutineFormValuesNotifierProvider =
-    AutoDisposeAsyncNotifierProvider<UpdatedRoutineFormValuesNotifier,
-        RoutineFormValues>.internal(
+final updatedRoutineFormValuesNotifierProvider = AutoDisposeNotifierProvider<
+    UpdatedRoutineFormValuesNotifier, RoutineFormValues>.internal(
   UpdatedRoutineFormValuesNotifier.new,
   name: r'updatedRoutineFormValuesNotifierProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -45,6 +44,6 @@ final updatedRoutineFormValuesNotifierProvider =
 );
 
 typedef _$UpdatedRoutineFormValuesNotifier
-    = AutoDisposeAsyncNotifier<RoutineFormValues>;
+    = AutoDisposeNotifier<RoutineFormValues>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/routine/ui/component/delete_routine.dart
+++ b/lib/feature/routine/ui/component/delete_routine.dart
@@ -13,34 +13,27 @@ class DeleteCurrentRoutineButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncValue = ref.watch(currentRoutineProvider);
-    return asyncValue.whenWidget(
-      data: (routine) {
-        if (routine == null) {
-          return const SizedBox();
-        }
+    final routine = ref.watch(currentRoutineProvider);
+    if (routine == null) {
+      return const SizedBox();
+    }
 
-        final deleteProvider = deleteRoutineUseCaseProvider(routine);
-
-        ref.listenAsync(
-          deleteProvider,
-          success: (_) => context.pop(),
-        );
-
-        final isLoading = ref.watch(deleteProvider).isLoading;
-        return TextButton(
-          onPressed: () => ref.read(deleteProvider.notifier).invoke(),
-          child: isLoading
-              ? const ButtonLoading()
-              : Text(
-                  'ルーティーンを削除',
-                  style: TextStyle(
-                    color: context.error,
-                  ),
-                ),
-        );
-      },
-      loading: SizedBox.new,
+    final deleteProvider = deleteRoutineUseCaseProvider(routine);
+    ref.listenAsync(
+      deleteProvider,
+      success: (_) => context.pop(),
+    );
+    final isLoading = ref.watch(deleteProvider).isLoading;
+    return TextButton(
+      onPressed: () => ref.read(deleteProvider.notifier).invoke(),
+      child: isLoading
+          ? const ButtonLoading()
+          : Text(
+              'ルーティーンを削除',
+              style: TextStyle(
+                color: context.error,
+              ),
+            ),
     );
   }
 }

--- a/lib/feature/routine/ui/routine_index_page.dart
+++ b/lib/feature/routine/ui/routine_index_page.dart
@@ -82,7 +82,7 @@ class _ListTile extends ConsumerWidget {
         ],
       ),
       child: ListTile(
-        onTap: () => RoutineUpdateRoute(routineId: routine.id).go(context),
+        onTap: () => RoutineUpdateRoute.fromRoutine(routine).go(context),
         title: Text(
           routine.notificationTimeOfDay.format(context),
           style: context.displayMedium?.copyWith(

--- a/lib/feature/routine/ui/routine_update_page.dart
+++ b/lib/feature/routine/ui/routine_update_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
-import '../../../core/ui/component/riverpod.dart';
 import '../state/routine_form_values.dart';
 import 'component/delete_routine.dart';
 import 'component/update_routine.dart';
@@ -56,34 +55,30 @@ class _NotificationTimeButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncValue = ref.watch(
+    final notificationTimeOfDay = ref.watch(
       updatedRoutineFormValuesNotifierProvider.select(
-        (value) => value.whenData((value) => value.notificationTimeOfDay),
+        (value) => value.notificationTimeOfDay,
       ),
     );
-    return asyncValue.whenWidget(
-      data: (notificationTimeOfDay) {
-        return TextButton(
-          onPressed: () async {
-            final time = await showTimePicker(
-              context: context,
-              initialTime: notificationTimeOfDay,
-            );
-            if (time != null) {
-              ref
-                  .read(updatedRoutineFormValuesNotifierProvider.notifier)
-                  .updateNotificationTime(time);
-            }
-          },
-          child: Text(
-            notificationTimeOfDay.format(context),
-            style: const TextStyle(
-              fontSize: 32,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
+    return TextButton(
+      onPressed: () async {
+        final time = await showTimePicker(
+          context: context,
+          initialTime: notificationTimeOfDay,
         );
+        if (time != null) {
+          ref
+              .read(updatedRoutineFormValuesNotifierProvider.notifier)
+              .updateNotificationTime(time);
+        }
       },
+      child: Text(
+        notificationTimeOfDay.format(context),
+        style: const TextStyle(
+          fontSize: 32,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
     );
   }
 }
@@ -93,22 +88,18 @@ class _EnableSoundListTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncValue = ref.watch(
+    final enableSound = ref.watch(
       updatedRoutineFormValuesNotifierProvider.select(
-        (value) => value.whenData((value) => value.enableSound),
+        (value) => value.enableSound,
       ),
     );
-    return asyncValue.whenWidget(
-      data: (enableSound) {
-        return SwitchListTile(
-          title: const Text('サウンド通知'),
-          value: enableSound,
-          onChanged: (value) {
-            ref
-                .read(updatedRoutineFormValuesNotifierProvider.notifier)
-                .updateEnableSound(value);
-          },
-        );
+    return SwitchListTile(
+      title: const Text('サウンド通知'),
+      value: enableSound,
+      onChanged: (value) {
+        ref
+            .read(updatedRoutineFormValuesNotifierProvider.notifier)
+            .updateEnableSound(value);
       },
     );
   }
@@ -119,22 +110,17 @@ class _EnablePushListTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncValue = ref.watch(
-      updatedRoutineFormValuesNotifierProvider.select(
-        (value) => value.whenData((value) => value.enablePush),
-      ),
+    final enablePush = ref.watch(
+      updatedRoutineFormValuesNotifierProvider
+          .select((value) => value.enablePush),
     );
-    return asyncValue.whenWidget(
-      data: (enablePush) {
-        return SwitchListTile(
-          title: const Text('プッシュ通知'),
-          value: enablePush,
-          onChanged: (value) {
-            ref
-                .read(updatedRoutineFormValuesNotifierProvider.notifier)
-                .updateEnablePush(value);
-          },
-        );
+    return SwitchListTile(
+      title: const Text('プッシュ通知'),
+      value: enablePush,
+      onChanged: (value) {
+        ref
+            .read(updatedRoutineFormValuesNotifierProvider.notifier)
+            .updateEnablePush(value);
       },
     );
   }

--- a/lib/feature/routine/ui/routine_update_page.dart
+++ b/lib/feature/routine/ui/routine_update_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
+import '../../../core/ui/component/riverpod.dart';
 import '../state/routine_form_values.dart';
 import 'component/delete_routine.dart';
 import 'component/update_routine.dart';
@@ -55,29 +56,34 @@ class _NotificationTimeButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final notificationTimeOfDay = ref.watch(
-      updatedRoutineFormValuesNotifierProvider
-          .select((value) => value.requireValue.notificationTimeOfDay),
-    );
-    return TextButton(
-      onPressed: () async {
-        final time = await showTimePicker(
-          context: context,
-          initialTime: notificationTimeOfDay,
-        );
-        if (time != null) {
-          ref
-              .read(updatedRoutineFormValuesNotifierProvider.notifier)
-              .updateNotificationTime(time);
-        }
-      },
-      child: Text(
-        notificationTimeOfDay.format(context),
-        style: const TextStyle(
-          fontSize: 32,
-          fontWeight: FontWeight.bold,
-        ),
+    final asyncValue = ref.watch(
+      updatedRoutineFormValuesNotifierProvider.select(
+        (value) => value.whenData((value) => value.notificationTimeOfDay),
       ),
+    );
+    return asyncValue.whenWidget(
+      data: (notificationTimeOfDay) {
+        return TextButton(
+          onPressed: () async {
+            final time = await showTimePicker(
+              context: context,
+              initialTime: notificationTimeOfDay,
+            );
+            if (time != null) {
+              ref
+                  .read(updatedRoutineFormValuesNotifierProvider.notifier)
+                  .updateNotificationTime(time);
+            }
+          },
+          child: Text(
+            notificationTimeOfDay.format(context),
+            style: const TextStyle(
+              fontSize: 32,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        );
+      },
     );
   }
 }
@@ -87,17 +93,22 @@ class _EnableSoundListTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final enableSound = ref.watch(
-      updatedRoutineFormValuesNotifierProvider
-          .select((value) => value.requireValue.enableSound),
+    final asyncValue = ref.watch(
+      updatedRoutineFormValuesNotifierProvider.select(
+        (value) => value.whenData((value) => value.enableSound),
+      ),
     );
-    return SwitchListTile(
-      title: const Text('サウンド通知'),
-      value: enableSound,
-      onChanged: (value) {
-        ref
-            .read(updatedRoutineFormValuesNotifierProvider.notifier)
-            .updateEnableSound(value);
+    return asyncValue.whenWidget(
+      data: (enableSound) {
+        return SwitchListTile(
+          title: const Text('サウンド通知'),
+          value: enableSound,
+          onChanged: (value) {
+            ref
+                .read(updatedRoutineFormValuesNotifierProvider.notifier)
+                .updateEnableSound(value);
+          },
+        );
       },
     );
   }
@@ -108,17 +119,22 @@ class _EnablePushListTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final enablePush = ref.watch(
-      updatedRoutineFormValuesNotifierProvider
-          .select((value) => value.requireValue.enablePush),
+    final asyncValue = ref.watch(
+      updatedRoutineFormValuesNotifierProvider.select(
+        (value) => value.whenData((value) => value.enablePush),
+      ),
     );
-    return SwitchListTile(
-      title: const Text('プッシュ通知'),
-      value: enablePush,
-      onChanged: (value) {
-        ref
-            .read(updatedRoutineFormValuesNotifierProvider.notifier)
-            .updateEnablePush(value);
+    return asyncValue.whenWidget(
+      data: (enablePush) {
+        return SwitchListTile(
+          title: const Text('プッシュ通知'),
+          value: enablePush,
+          onChanged: (value) {
+            ref
+                .read(updatedRoutineFormValuesNotifierProvider.notifier)
+                .updateEnablePush(value);
+          },
+        );
       },
     );
   }

--- a/lib/feature/routine/use_case/update_routine.dart
+++ b/lib/feature/routine/use_case/update_routine.dart
@@ -20,12 +20,11 @@ class UpdateRoutineUseCase extends _$UpdateRoutineUseCase {
     state = await AsyncValue.guard(() async {
       final isar = ref.read(isarProvider);
       await isar.writeTxn(() async {
-        final routine = await ref.read(currentRoutineProvider.future);
+        final routine = ref.read(currentRoutineProvider);
         if (routine == null) {
           throw StateError('Routine is not found');
         }
-        final formValues =
-            ref.read(updatedRoutineFormValuesNotifierProvider).requireValue;
+        final formValues = ref.read(updatedRoutineFormValuesNotifierProvider);
         await isar.routines.put(formValues.toEntity(routine));
       });
     });

--- a/lib/feature/routine/use_case/update_routine.g.dart
+++ b/lib/feature/routine/use_case/update_routine.g.dart
@@ -7,7 +7,7 @@ part of 'update_routine.dart';
 // **************************************************************************
 
 String _$updateRoutineUseCaseHash() =>
-    r'9044b10834393b7029c1938ef051a782e9687309';
+    r'26ce1c04d8d2578094e9819fe2bf06922fdd755b';
 
 /// See also [UpdateRoutineUseCase].
 @ProviderFor(UpdateRoutineUseCase)

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../feature/routine/data/routine.dart';
 import '../feature/routine/state/current_routine.dart';
 import '../feature/routine/ui/routine_add_page.dart';
 import '../feature/routine/ui/routine_index_page.dart';
@@ -52,15 +53,24 @@ class RoutineAddRoute extends GoRouteData {
 class RoutineUpdateRoute extends GoRouteData {
   const RoutineUpdateRoute({
     required this.routineId,
+    this.$extra,
   });
 
+  factory RoutineUpdateRoute.fromRoutine(Routine routine) => RoutineUpdateRoute(
+        routineId: routine.id,
+        $extra: routine,
+      );
+
   final int routineId;
+  final Routine? $extra;
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return ProviderScope(
       overrides: [
-        currentRoutineIdProvider.overrideWithValue(routineId),
+        currentRoutineParamsProvider.overrideWithValue(
+          RoutineParams(routineId: routineId, cache: $extra),
+        ),
       ],
       child: const RoutineUpdatePage(),
     );

--- a/lib/router/router.g.dart
+++ b/lib/router/router.g.dart
@@ -65,20 +65,23 @@ extension $RoutineUpdateRouteExtension on RoutineUpdateRoute {
   static RoutineUpdateRoute _fromState(GoRouterState state) =>
       RoutineUpdateRoute(
         routineId: int.parse(state.pathParameters['routineId']!),
+        $extra: state.extra as Routine?,
       );
 
   String get location => GoRouteData.$location(
         '/routine/${Uri.encodeComponent(routineId.toString())}/update',
       );
 
-  void go(BuildContext context) => context.go(location);
+  void go(BuildContext context) => context.go(location, extra: $extra);
 
-  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+  Future<T?> push<T>(BuildContext context) =>
+      context.push<T>(location, extra: $extra);
 
   void pushReplacement(BuildContext context) =>
-      context.pushReplacement(location);
+      context.pushReplacement(location, extra: $extra);
 
-  void replace(BuildContext context) => context.replace(location);
+  void replace(BuildContext context) =>
+      context.replace(location, extra: $extra);
 }
 
 // **************************************************************************


### PR DESCRIPTION
# 関連する Issue

- #10

# やったこと

- go_router_builder の $extra に対応しました。
  - $extra を使えば、画面遷移時に任意のオブジェクトを渡すことができます。ルーティーンオブジェクトを渡すことで、これまで更新画面表示時に毎回 DB から取得していた処理が省略できます。
  - ちなみに、 $extra が null の場合は DB から取得するようにしていますが、iOS / Android では null になることはありません。null になるのは Flutter Web で更新画面が再読み込みされた場合のみです。とはいえ、プログラム上は null になり得るので一応考慮しておきました。
- 更新画面表示時に例外が発生していた問題を修正しました。
  - 更新画面で `requireValue` を参照していましたが、DB からの非同期取得処理があるので、ローディング状態を考慮するように修正しました。
  - と思ったんですが、isar には同期的にデータを取得する `getSync()` があるのを思い出しました。`getSync()` を使えばローディング状態を意識する必要はなくなりました。

# やらないこと

- 繰り返し設定は未実装

# スクリーンショット

あれば貼り付ける
