### PR TITLE
通知機能

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,6 +28,7 @@ android {
     ndkVersion flutter.ndkVersion
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -49,6 +50,7 @@ android {
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -64,4 +66,8 @@ flutter {
     source '../..'
 }
 
-dependencies {}
+dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+    implementation 'androidx.window:window:1.0.0'
+    implementation 'androidx.window:window-java:1.0.0'
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <application
         android:label="repeat_notification_app"
         android:name="${applicationName}"
@@ -29,5 +31,15 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+            </intent-filter>
+        </receiver>
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ActionBroadcastReceiver" />
     </application>
 </manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,9 @@
 PODS:
   - Flutter (1.0.0)
+  - flutter_local_notifications (0.0.1):
+    - Flutter
+  - flutter_timezone (0.0.1):
+    - Flutter
   - isar_flutter_libs (1.0.0):
     - Flutter
   - path_provider_foundation (0.0.1):
@@ -8,12 +12,18 @@ PODS:
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
+  - flutter_timezone (from `.symlinks/plugins/flutter_timezone/ios`)
   - isar_flutter_libs (from `.symlinks/plugins/isar_flutter_libs/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
+  flutter_timezone:
+    :path: ".symlinks/plugins/flutter_timezone/ios"
   isar_flutter_libs:
     :path: ".symlinks/plugins/isar_flutter_libs/ios"
   path_provider_foundation:
@@ -21,6 +31,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
+  flutter_timezone: ffb07bdad3c6276af8dada0f11978d8a1f8a20bb
   isar_flutter_libs: b69f437aeab9c521821c3f376198c4371fa21073
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -7,6 +7,9 @@ import Flutter
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    if #available(iOS 10.0, *) {
+      UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
+    }
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'core/ui/component/local_notifications.dart';
 import 'router/router.dart';
 import 'theme/theme.dart';
 
@@ -20,6 +21,11 @@ class App extends ConsumerWidget {
       localizationsDelegates: GlobalMaterialLocalizations.delegates,
       supportedLocales: const [Locale('ja')],
       routerConfig: appRouter.config(),
+      builder: (context, child) {
+        return LocalNotifications(
+          child: child!,
+        );
+      },
     );
   }
 }

--- a/lib/core/data/local_notifications/local_notifications.dart
+++ b/lib/core/data/local_notifications/local_notifications.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'local_notifications.g.dart';
+
+@Riverpod(keepAlive: true)
+FlutterLocalNotificationsPlugin localNotificationsPlugin(
+  LocalNotificationsPluginRef ref,
+) {
+  throw UnimplementedError();
+}
+
+extension FlutterLocalNotificationsPluginX on FlutterLocalNotificationsPlugin {
+  /// ローカル通知の許可を求める
+  Future<bool?> requestPermission() async {
+    if (Platform.isIOS) {
+      return await resolvePlatformSpecificImplementation<
+              IOSFlutterLocalNotificationsPlugin>()
+          ?.requestPermissions(
+        alert: true,
+        badge: true,
+        sound: true,
+      );
+    } else if (Platform.isAndroid) {
+      return await resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>()
+          ?.requestNotificationsPermission();
+    }
+    return null;
+  }
+}

--- a/lib/core/data/local_notifications/local_notifications.g.dart
+++ b/lib/core/data/local_notifications/local_notifications.g.dart
@@ -1,26 +1,28 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'add_routine.dart';
+part of 'local_notifications.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$addRoutineUseCaseHash() => r'642a82f6ef298ad1252570378de6ed0f7ac44d31';
+String _$localNotificationsPluginHash() =>
+    r'30ca765ee5d089c8c221eb2b5c5984db531880cd';
 
-/// See also [AddRoutineUseCase].
-@ProviderFor(AddRoutineUseCase)
-final addRoutineUseCaseProvider =
-    AutoDisposeAsyncNotifierProvider<AddRoutineUseCase, void>.internal(
-  AddRoutineUseCase.new,
-  name: r'addRoutineUseCaseProvider',
+/// See also [localNotificationsPlugin].
+@ProviderFor(localNotificationsPlugin)
+final localNotificationsPluginProvider =
+    Provider<FlutterLocalNotificationsPlugin>.internal(
+  localNotificationsPlugin,
+  name: r'localNotificationsPluginProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$addRoutineUseCaseHash,
+      : _$localNotificationsPluginHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
-typedef _$AddRoutineUseCase = AutoDisposeAsyncNotifier<void>;
+typedef LocalNotificationsPluginRef
+    = ProviderRef<FlutterLocalNotificationsPlugin>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/core/ui/component/local_notifications.dart
+++ b/lib/core/ui/component/local_notifications.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../util/logger.dart';
+import '../../data/local_notifications/local_notifications.dart';
+
+class LocalNotifications extends ConsumerStatefulWidget {
+  const LocalNotifications({
+    super.key,
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  ConsumerState<LocalNotifications> createState() => _LocalNotificationsState();
+}
+
+class _LocalNotificationsState extends ConsumerState<LocalNotifications> {
+  @override
+  void initState() {
+    super.initState();
+    final plugin = ref.read(localNotificationsPluginProvider);
+    unawaited(plugin.requestPermission());
+    unawaited(
+      plugin.initialize(
+        InitializationSettings(
+          android: const AndroidInitializationSettings(
+            '@mipmap/ic_launcher',
+          ),
+          iOS: DarwinInitializationSettings(
+            onDidReceiveLocalNotification: _onDidReceiveLocalNotification,
+          ),
+        ),
+        onDidReceiveNotificationResponse: _onDidReceiveNotificationResponse,
+      ),
+    );
+  }
+
+  Future<void> _onDidReceiveLocalNotification(
+    int id,
+    String? title,
+    String? body,
+    String? payload,
+  ) async {
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) => CupertinoAlertDialog(
+        title: Text(title ?? ''),
+        content: Text(body ?? ''),
+        actions: [
+          CupertinoDialogAction(
+            isDefaultAction: true,
+            child: const Text('Ok'),
+            onPressed: () async {
+              Navigator.of(context, rootNavigator: true).pop();
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// ローカル通知をタップしたときに呼ばれる
+  ///
+  /// アプリ起動中のみ呼ばれる。アプリがキルされている場合は呼ばれない。
+  Future<void> _onDidReceiveNotificationResponse(
+    NotificationResponse notificationResponse,
+  ) async {
+    logger.i('notification payload = ${notificationResponse.payload}');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/lib/core/ui/component/local_notifications.dart
+++ b/lib/core/ui/component/local_notifications.dart
@@ -24,10 +24,10 @@ class _LocalNotificationsState extends ConsumerState<LocalNotifications> {
   @override
   void initState() {
     super.initState();
-    final plugin = ref.read(localNotificationsPluginProvider);
-    unawaited(plugin.requestPermission());
-    unawaited(
-      plugin.initialize(
+    unawaited(() async {
+      final plugin = ref.read(localNotificationsPluginProvider);
+      await plugin.requestPermission();
+      await plugin.initialize(
         InitializationSettings(
           android: const AndroidInitializationSettings(
             '@mipmap/ic_launcher',
@@ -37,8 +37,8 @@ class _LocalNotificationsState extends ConsumerState<LocalNotifications> {
           ),
         ),
         onDidReceiveNotificationResponse: _onDidReceiveNotificationResponse,
-      ),
-    );
+      );
+    }());
   }
 
   Future<void> _onDidReceiveLocalNotification(

--- a/lib/core/ui/component/local_notifications.dart
+++ b/lib/core/ui/component/local_notifications.dart
@@ -28,41 +28,14 @@ class _LocalNotificationsState extends ConsumerState<LocalNotifications> {
       final plugin = ref.read(localNotificationsPluginProvider);
       await plugin.requestPermission();
       await plugin.initialize(
-        InitializationSettings(
-          android: const AndroidInitializationSettings(
+        const InitializationSettings(
+          android: AndroidInitializationSettings(
             '@mipmap/ic_launcher',
-          ),
-          iOS: DarwinInitializationSettings(
-            onDidReceiveLocalNotification: _onDidReceiveLocalNotification,
           ),
         ),
         onDidReceiveNotificationResponse: _onDidReceiveNotificationResponse,
       );
     }());
-  }
-
-  Future<void> _onDidReceiveLocalNotification(
-    int id,
-    String? title,
-    String? body,
-    String? payload,
-  ) async {
-    await showDialog<void>(
-      context: context,
-      builder: (BuildContext context) => CupertinoAlertDialog(
-        title: Text(title ?? ''),
-        content: Text(body ?? ''),
-        actions: [
-          CupertinoDialogAction(
-            isDefaultAction: true,
-            child: const Text('Ok'),
-            onPressed: () async {
-              Navigator.of(context, rootNavigator: true).pop();
-            },
-          ),
-        ],
-      ),
-    );
   }
 
   /// ローカル通知をタップしたときに呼ばれる

--- a/lib/core/ui/component/local_notifications.dart
+++ b/lib/core/ui/component/local_notifications.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -26,7 +25,11 @@ class _LocalNotificationsState extends ConsumerState<LocalNotifications> {
     super.initState();
     unawaited(() async {
       final plugin = ref.read(localNotificationsPluginProvider);
-      await plugin.requestPermission();
+      final result = await plugin.requestPermission();
+      logger.i('requestPermission result = $result');
+      if (result == null || !result) {
+        return;
+      }
       await plugin.initialize(
         const InitializationSettings(
           android: AndroidInitializationSettings(

--- a/lib/feature/debug/data/pending_notification_request.dart
+++ b/lib/feature/debug/data/pending_notification_request.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/data/local_notifications/local_notifications.dart';
+
+part 'pending_notification_request.g.dart';
+
+@riverpod
+FutureOr<List<PendingNotificationRequest>> pendingNotificationRequests(
+  PendingNotificationRequestsRef ref,
+) async {
+  return ref
+      .read(localNotificationsPluginProvider)
+      .pendingNotificationRequests();
+}

--- a/lib/feature/debug/data/pending_notification_request.g.dart
+++ b/lib/feature/debug/data/pending_notification_request.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pending_notification_request.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$pendingNotificationRequestsHash() =>
+    r'498a0b15f5f0b1005c5ed0fab01a55418e70ee21';
+
+/// See also [pendingNotificationRequests].
+@ProviderFor(pendingNotificationRequests)
+final pendingNotificationRequestsProvider =
+    AutoDisposeFutureProvider<List<PendingNotificationRequest>>.internal(
+  pendingNotificationRequests,
+  name: r'pendingNotificationRequestsProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$pendingNotificationRequestsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef PendingNotificationRequestsRef
+    = AutoDisposeFutureProviderRef<List<PendingNotificationRequest>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/debug/state/local_notifications.dart
+++ b/lib/feature/debug/state/local_notifications.dart
@@ -1,0 +1,37 @@
+import 'package:collection/collection.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/data/isar/isar.dart';
+import '../../routine/data/routine.dart';
+import '../../routine/state/local_notifications.dart';
+import '../data/pending_notification_request.dart';
+
+part 'local_notifications.g.dart';
+
+/// 端末に登録済みの通知要求の一覧を取得して、[RoutineLocalNotification] に変換して返す。
+@riverpod
+FutureOr<List<RoutineLocalNotification>> registeredRoutineLocalNotifications(
+  RegisteredRoutineLocalNotificationsRef ref,
+) async {
+  final pendingNotificationRequests =
+      await ref.watch(pendingNotificationRequestsProvider.future);
+  final allRoutineIds = pendingNotificationRequests
+      .map((e) => RoutineLocalNotification.extractRoutineId(e.id))
+      .toSet();
+  final isar = ref.watch(isarProvider);
+  final allRoutines = await Future.wait(
+    allRoutineIds.map((id) async {
+      return isar.routines.get(id);
+    }),
+  );
+  final allLocalNotifications =
+      allRoutines.whereType<Routine>().expand((routine) {
+    return routine.toNotifications();
+  }).toList();
+  return allLocalNotifications.where((localNotification) {
+    return pendingNotificationRequests.firstWhereOrNull(
+          (request) => request.id == localNotification.notificationId,
+        ) !=
+        null;
+  }).toList();
+}

--- a/lib/feature/debug/state/local_notifications.g.dart
+++ b/lib/feature/debug/state/local_notifications.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'local_notifications.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$registeredRoutineLocalNotificationsHash() =>
+    r'967a581bf14d252626c514afb148bf3294988eee';
+
+/// See also [registeredRoutineLocalNotifications].
+@ProviderFor(registeredRoutineLocalNotifications)
+final registeredRoutineLocalNotificationsProvider =
+    AutoDisposeFutureProvider<List<RoutineLocalNotification>>.internal(
+  registeredRoutineLocalNotifications,
+  name: r'registeredRoutineLocalNotificationsProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$registeredRoutineLocalNotificationsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef RegisteredRoutineLocalNotificationsRef
+    = AutoDisposeFutureProviderRef<List<RoutineLocalNotification>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/debug/state/local_notifications.g.dart
+++ b/lib/feature/debug/state/local_notifications.g.dart
@@ -9,7 +9,9 @@ part of 'local_notifications.dart';
 String _$registeredRoutineLocalNotificationsHash() =>
     r'967a581bf14d252626c514afb148bf3294988eee';
 
-/// See also [registeredRoutineLocalNotifications].
+/// 端末に登録済みの通知要求の一覧を取得して、[RoutineLocalNotification] に変換して返す。
+///
+/// Copied from [registeredRoutineLocalNotifications].
 @ProviderFor(registeredRoutineLocalNotifications)
 final registeredRoutineLocalNotificationsProvider =
     AutoDisposeFutureProvider<List<RoutineLocalNotification>>.internal(

--- a/lib/feature/debug/ui/component/navigate_debug_button.dart
+++ b/lib/feature/debug/ui/component/navigate_debug_button.dart
@@ -1,0 +1,16 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../router/router.dart';
+
+class NavigateDebugButton extends StatelessWidget {
+  const NavigateDebugButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: () => context.navigateTo(const DebugRouterRoute()),
+      icon: const Icon(Icons.build_rounded),
+    );
+  }
+}

--- a/lib/feature/debug/ui/debug_page.dart
+++ b/lib/feature/debug/ui/debug_page.dart
@@ -1,0 +1,43 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../router/router.dart';
+
+@RoutePage()
+class DebugPage extends StatelessWidget {
+  const DebugPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: const AutoLeadingButton(),
+        title: const Text('デバッグ'),
+      ),
+      body: const SafeArea(
+        child: _Body(),
+      ),
+    );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          ListTile(
+            onTap: () => context
+                .navigateTo(const RegisteredLocalNotificationIndexRoute()),
+            title: const Text('登録済み通知一覧'),
+            trailing: const Icon(Icons.arrow_forward_ios),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/debug/ui/debug_router_page.dart
+++ b/lib/feature/debug/ui/debug_router_page.dart
@@ -1,0 +1,6 @@
+import 'package:auto_route/auto_route.dart';
+
+@RoutePage()
+class DebugRouterPage extends AutoRouter {
+  const DebugRouterPage({super.key});
+}

--- a/lib/feature/debug/ui/registered_local_notification_index_page.dart
+++ b/lib/feature/debug/ui/registered_local_notification_index_page.dart
@@ -1,0 +1,102 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+import '../../../core/ui/component/button_loading.dart';
+import '../../../core/ui/component/material.dart';
+import '../../../core/ui/component/riverpod.dart';
+import '../../routine/state/local_notifications.dart';
+import '../state/local_notifications.dart';
+import '../use_case/clear_all_local_notification.dart';
+
+@RoutePage()
+class RegisteredLocalNotificationIndexPage extends StatelessWidget {
+  const RegisteredLocalNotificationIndexPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('登録済み通知一覧'),
+        actions: const [
+          _ClearAllButton(),
+        ],
+      ),
+      body: const SafeArea(
+        child: _Body(),
+      ),
+    );
+  }
+}
+
+class _ClearAllButton extends ConsumerWidget {
+  const _ClearAllButton();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listenAsync(clearAllLocalNotificationUseCaseProvider);
+    final isLoading =
+        ref.watch(clearAllLocalNotificationUseCaseProvider).isLoading;
+    return IconButton(
+      onPressed: isLoading
+          ? null
+          : () => ref
+              .read(clearAllLocalNotificationUseCaseProvider.notifier)
+              .invoke(),
+      icon: isLoading ? const ButtonLoading() : const Icon(Icons.clear_all),
+    );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncValue = ref.watch(registeredRoutineLocalNotificationsProvider);
+    return asyncValue.whenWidget(
+      data: (notifications) {
+        if (notifications.isEmpty) {
+          return const Center(
+            child: Text('通知がありません'),
+          );
+        }
+        return ListView.builder(
+          itemCount: notifications.length,
+          itemBuilder: (context, index) =>
+              _ListTile(notification: notifications[index]),
+        );
+      },
+    );
+  }
+}
+
+class _ListTile extends ConsumerWidget {
+  const _ListTile({
+    required this.notification,
+  });
+
+  final RoutineLocalNotification notification;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final scheduledDtime = notification.scheduledDate.toDateTime();
+    return ListTile(
+      leading:
+          Text('${notification.notificationId}', style: context.titleMedium),
+      title: Text(
+        '${DateFormat.yMEd('ja').format(scheduledDtime)} '
+        '${DateFormat.Hm('ja').format(scheduledDtime)}',
+      ),
+      subtitle: Text('繰り返し: ${notification.dateTimeComponents?.name}'),
+    );
+  }
+}
+
+extension on tz.TZDateTime {
+  DateTime toDateTime() {
+    return DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch);
+  }
+}

--- a/lib/feature/debug/use_case/clear_all_local_notification.dart
+++ b/lib/feature/debug/use_case/clear_all_local_notification.dart
@@ -1,0 +1,24 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/data/local_notifications/local_notifications.dart';
+import '../data/pending_notification_request.dart';
+
+part 'clear_all_local_notification.g.dart';
+
+@riverpod
+class ClearAllLocalNotificationUseCase
+    extends _$ClearAllLocalNotificationUseCase {
+  @override
+  FutureOr<void> build() => null;
+
+  Future<void> invoke() async {
+    if (state.isLoading) {
+      return;
+    }
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() async {
+      await ref.read(localNotificationsPluginProvider).cancelAll();
+      ref.invalidate(pendingNotificationRequestsProvider);
+    });
+  }
+}

--- a/lib/feature/debug/use_case/clear_all_local_notification.g.dart
+++ b/lib/feature/debug/use_case/clear_all_local_notification.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'clear_all_local_notification.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$clearAllLocalNotificationUseCaseHash() =>
+    r'a0a4b76703269c8e072f12bd7e9127221183c000';
+
+/// See also [ClearAllLocalNotificationUseCase].
+@ProviderFor(ClearAllLocalNotificationUseCase)
+final clearAllLocalNotificationUseCaseProvider =
+    AutoDisposeAsyncNotifierProvider<ClearAllLocalNotificationUseCase,
+        void>.internal(
+  ClearAllLocalNotificationUseCase.new,
+  name: r'clearAllLocalNotificationUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$clearAllLocalNotificationUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ClearAllLocalNotificationUseCase = AutoDisposeAsyncNotifier<void>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/routine/data/routine.dart
+++ b/lib/feature/routine/data/routine.dart
@@ -19,6 +19,9 @@ class Routine {
   /// サウンド通知の有無
   bool enableSound = true;
 
+  /// ラベル
+  String label = 'アラーム';
+
   /// 作成日時
   DateTime createdAt = DateTime.now();
 

--- a/lib/feature/routine/data/routine.dart
+++ b/lib/feature/routine/data/routine.dart
@@ -19,9 +19,6 @@ class Routine {
   /// サウンド通知の有無
   bool enableSound = true;
 
-  /// プッシュ通知の有無
-  bool enablePush = true;
-
   /// 作成日時
   DateTime createdAt = DateTime.now();
 

--- a/lib/feature/routine/data/routine.g.dart
+++ b/lib/feature/routine/data/routine.g.dart
@@ -22,34 +22,29 @@ const RoutineSchema = CollectionSchema(
       name: r'createdAt',
       type: IsarType.dateTime,
     ),
-    r'enablePush': PropertySchema(
-      id: 1,
-      name: r'enablePush',
-      type: IsarType.bool,
-    ),
     r'enableSound': PropertySchema(
-      id: 2,
+      id: 1,
       name: r'enableSound',
       type: IsarType.bool,
     ),
     r'notificationTime': PropertySchema(
-      id: 3,
+      id: 2,
       name: r'notificationTime',
       type: IsarType.long,
     ),
     r'repetitionWeeks': PropertySchema(
-      id: 4,
+      id: 3,
       name: r'repetitionWeeks',
       type: IsarType.stringList,
       enumMap: _RoutinerepetitionWeeksEnumValueMap,
     ),
     r'state': PropertySchema(
-      id: 5,
+      id: 4,
       name: r'state',
       type: IsarType.bool,
     ),
     r'updatedAt': PropertySchema(
-      id: 6,
+      id: 5,
       name: r'updatedAt',
       type: IsarType.dateTime,
     )
@@ -105,13 +100,12 @@ void _routineSerialize(
   Map<Type, List<int>> allOffsets,
 ) {
   writer.writeDateTime(offsets[0], object.createdAt);
-  writer.writeBool(offsets[1], object.enablePush);
-  writer.writeBool(offsets[2], object.enableSound);
-  writer.writeLong(offsets[3], object.notificationTime);
+  writer.writeBool(offsets[1], object.enableSound);
+  writer.writeLong(offsets[2], object.notificationTime);
   writer.writeStringList(
-      offsets[4], object.repetitionWeeks.map((e) => e.name).toList());
-  writer.writeBool(offsets[5], object.state);
-  writer.writeDateTime(offsets[6], object.updatedAt);
+      offsets[3], object.repetitionWeeks.map((e) => e.name).toList());
+  writer.writeBool(offsets[4], object.state);
+  writer.writeDateTime(offsets[5], object.updatedAt);
 }
 
 Routine _routineDeserialize(
@@ -122,18 +116,17 @@ Routine _routineDeserialize(
 ) {
   final object = Routine();
   object.createdAt = reader.readDateTime(offsets[0]);
-  object.enablePush = reader.readBool(offsets[1]);
-  object.enableSound = reader.readBool(offsets[2]);
+  object.enableSound = reader.readBool(offsets[1]);
   object.id = id;
-  object.notificationTime = reader.readLong(offsets[3]);
+  object.notificationTime = reader.readLong(offsets[2]);
   object.repetitionWeeks = reader
-          .readStringList(offsets[4])
+          .readStringList(offsets[3])
           ?.map((e) =>
               _RoutinerepetitionWeeksValueEnumMap[e] ?? RepetitionWeek.monday)
           .toList() ??
       [];
-  object.state = reader.readBool(offsets[5]);
-  object.updatedAt = reader.readDateTime(offsets[6]);
+  object.state = reader.readBool(offsets[4]);
+  object.updatedAt = reader.readDateTime(offsets[5]);
   return object;
 }
 
@@ -149,10 +142,8 @@ P _routineDeserializeProp<P>(
     case 1:
       return (reader.readBool(offset)) as P;
     case 2:
-      return (reader.readBool(offset)) as P;
-    case 3:
       return (reader.readLong(offset)) as P;
-    case 4:
+    case 3:
       return (reader
               .readStringList(offset)
               ?.map((e) =>
@@ -160,9 +151,9 @@ P _routineDeserializeProp<P>(
                   RepetitionWeek.monday)
               .toList() ??
           []) as P;
-    case 5:
+    case 4:
       return (reader.readBool(offset)) as P;
-    case 6:
+    case 5:
       return (reader.readDateTime(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -424,16 +415,6 @@ extension RoutineQueryFilter
         includeLower: includeLower,
         upper: upper,
         includeUpper: includeUpper,
-      ));
-    });
-  }
-
-  QueryBuilder<Routine, Routine, QAfterFilterCondition> enablePushEqualTo(
-      bool value) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.equalTo(
-        property: r'enablePush',
-        value: value,
       ));
     });
   }
@@ -865,18 +846,6 @@ extension RoutineQuerySortBy on QueryBuilder<Routine, Routine, QSortBy> {
     });
   }
 
-  QueryBuilder<Routine, Routine, QAfterSortBy> sortByEnablePush() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'enablePush', Sort.asc);
-    });
-  }
-
-  QueryBuilder<Routine, Routine, QAfterSortBy> sortByEnablePushDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'enablePush', Sort.desc);
-    });
-  }
-
   QueryBuilder<Routine, Routine, QAfterSortBy> sortByEnableSound() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'enableSound', Sort.asc);
@@ -937,18 +906,6 @@ extension RoutineQuerySortThenBy
   QueryBuilder<Routine, Routine, QAfterSortBy> thenByCreatedAtDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'createdAt', Sort.desc);
-    });
-  }
-
-  QueryBuilder<Routine, Routine, QAfterSortBy> thenByEnablePush() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'enablePush', Sort.asc);
-    });
-  }
-
-  QueryBuilder<Routine, Routine, QAfterSortBy> thenByEnablePushDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'enablePush', Sort.desc);
     });
   }
 
@@ -1021,12 +978,6 @@ extension RoutineQueryWhereDistinct
     });
   }
 
-  QueryBuilder<Routine, Routine, QDistinct> distinctByEnablePush() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addDistinctBy(r'enablePush');
-    });
-  }
-
   QueryBuilder<Routine, Routine, QDistinct> distinctByEnableSound() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'enableSound');
@@ -1069,12 +1020,6 @@ extension RoutineQueryProperty
   QueryBuilder<Routine, DateTime, QQueryOperations> createdAtProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'createdAt');
-    });
-  }
-
-  QueryBuilder<Routine, bool, QQueryOperations> enablePushProperty() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addPropertyName(r'enablePush');
     });
   }
 

--- a/lib/feature/routine/data/routine.g.dart
+++ b/lib/feature/routine/data/routine.g.dart
@@ -27,24 +27,29 @@ const RoutineSchema = CollectionSchema(
       name: r'enableSound',
       type: IsarType.bool,
     ),
-    r'notificationTime': PropertySchema(
+    r'label': PropertySchema(
       id: 2,
+      name: r'label',
+      type: IsarType.string,
+    ),
+    r'notificationTime': PropertySchema(
+      id: 3,
       name: r'notificationTime',
       type: IsarType.long,
     ),
     r'repetitionWeeks': PropertySchema(
-      id: 3,
+      id: 4,
       name: r'repetitionWeeks',
       type: IsarType.stringList,
       enumMap: _RoutinerepetitionWeeksEnumValueMap,
     ),
     r'state': PropertySchema(
-      id: 4,
+      id: 5,
       name: r'state',
       type: IsarType.bool,
     ),
     r'updatedAt': PropertySchema(
-      id: 5,
+      id: 6,
       name: r'updatedAt',
       type: IsarType.dateTime,
     )
@@ -83,6 +88,7 @@ int _routineEstimateSize(
   Map<Type, List<int>> allOffsets,
 ) {
   var bytesCount = offsets.last;
+  bytesCount += 3 + object.label.length * 3;
   bytesCount += 3 + object.repetitionWeeks.length * 3;
   {
     for (var i = 0; i < object.repetitionWeeks.length; i++) {
@@ -101,11 +107,12 @@ void _routineSerialize(
 ) {
   writer.writeDateTime(offsets[0], object.createdAt);
   writer.writeBool(offsets[1], object.enableSound);
-  writer.writeLong(offsets[2], object.notificationTime);
+  writer.writeString(offsets[2], object.label);
+  writer.writeLong(offsets[3], object.notificationTime);
   writer.writeStringList(
-      offsets[3], object.repetitionWeeks.map((e) => e.name).toList());
-  writer.writeBool(offsets[4], object.state);
-  writer.writeDateTime(offsets[5], object.updatedAt);
+      offsets[4], object.repetitionWeeks.map((e) => e.name).toList());
+  writer.writeBool(offsets[5], object.state);
+  writer.writeDateTime(offsets[6], object.updatedAt);
 }
 
 Routine _routineDeserialize(
@@ -118,15 +125,16 @@ Routine _routineDeserialize(
   object.createdAt = reader.readDateTime(offsets[0]);
   object.enableSound = reader.readBool(offsets[1]);
   object.id = id;
-  object.notificationTime = reader.readLong(offsets[2]);
+  object.label = reader.readString(offsets[2]);
+  object.notificationTime = reader.readLong(offsets[3]);
   object.repetitionWeeks = reader
-          .readStringList(offsets[3])
+          .readStringList(offsets[4])
           ?.map((e) =>
               _RoutinerepetitionWeeksValueEnumMap[e] ?? RepetitionWeek.monday)
           .toList() ??
       [];
-  object.state = reader.readBool(offsets[4]);
-  object.updatedAt = reader.readDateTime(offsets[5]);
+  object.state = reader.readBool(offsets[5]);
+  object.updatedAt = reader.readDateTime(offsets[6]);
   return object;
 }
 
@@ -142,8 +150,10 @@ P _routineDeserializeProp<P>(
     case 1:
       return (reader.readBool(offset)) as P;
     case 2:
-      return (reader.readLong(offset)) as P;
+      return (reader.readString(offset)) as P;
     case 3:
+      return (reader.readLong(offset)) as P;
+    case 4:
       return (reader
               .readStringList(offset)
               ?.map((e) =>
@@ -151,9 +161,9 @@ P _routineDeserializeProp<P>(
                   RepetitionWeek.monday)
               .toList() ??
           []) as P;
-    case 4:
-      return (reader.readBool(offset)) as P;
     case 5:
+      return (reader.readBool(offset)) as P;
+    case 6:
       return (reader.readDateTime(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -477,6 +487,136 @@ extension RoutineQueryFilter
         includeLower: includeLower,
         upper: upper,
         includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterFilterCondition> labelEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'label',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterFilterCondition> labelGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'label',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterFilterCondition> labelLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'label',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterFilterCondition> labelBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'label',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterFilterCondition> labelStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'label',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterFilterCondition> labelEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'label',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterFilterCondition> labelContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'label',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterFilterCondition> labelMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'label',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterFilterCondition> labelIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'label',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterFilterCondition> labelIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'label',
+        value: '',
       ));
     });
   }
@@ -858,6 +998,18 @@ extension RoutineQuerySortBy on QueryBuilder<Routine, Routine, QSortBy> {
     });
   }
 
+  QueryBuilder<Routine, Routine, QAfterSortBy> sortByLabel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'label', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterSortBy> sortByLabelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'label', Sort.desc);
+    });
+  }
+
   QueryBuilder<Routine, Routine, QAfterSortBy> sortByNotificationTime() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'notificationTime', Sort.asc);
@@ -933,6 +1085,18 @@ extension RoutineQuerySortThenBy
     });
   }
 
+  QueryBuilder<Routine, Routine, QAfterSortBy> thenByLabel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'label', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Routine, Routine, QAfterSortBy> thenByLabelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'label', Sort.desc);
+    });
+  }
+
   QueryBuilder<Routine, Routine, QAfterSortBy> thenByNotificationTime() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'notificationTime', Sort.asc);
@@ -984,6 +1148,13 @@ extension RoutineQueryWhereDistinct
     });
   }
 
+  QueryBuilder<Routine, Routine, QDistinct> distinctByLabel(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'label', caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<Routine, Routine, QDistinct> distinctByNotificationTime() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'notificationTime');
@@ -1026,6 +1197,12 @@ extension RoutineQueryProperty
   QueryBuilder<Routine, bool, QQueryOperations> enableSoundProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'enableSound');
+    });
+  }
+
+  QueryBuilder<Routine, String, QQueryOperations> labelProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'label');
     });
   }
 

--- a/lib/feature/routine/state/local_notifications.dart
+++ b/lib/feature/routine/state/local_notifications.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:timezone/timezone.dart' as tz;
@@ -46,8 +48,13 @@ extension FlutterLocalNotificationsPluginX on FlutterLocalNotificationsPlugin {
         notification.scheduledDate,
         NotificationDetails(
           android: AndroidNotificationDetails(
-            'repeat-notification-${notification.notificationId}',
-            'repeat-notification',
+            // Androidにおいてサウンドを再生するかどうかはチャンネルIDを生成したときにのみ決定され、
+            // 変更することはできないため、毎回チャンネルIDが変わるようにランダムな文字列を付与する必要がある。
+            'repeat-notification-app-${routine.id}-${_generateNonce(6)}',
+
+            // チャンネル名は端末設定に表示されるため、ルーティン一覧画面でも表示しているわかりやすい名称にしている。
+            routine.title,
+            playSound: routine.enableSound,
           ),
         ),
         uiLocalNotificationDateInterpretation:
@@ -56,6 +63,19 @@ extension FlutterLocalNotificationsPluginX on FlutterLocalNotificationsPlugin {
         matchDateTimeComponents: notification.dateTimeComponents,
       );
     }
+  }
+
+  /// ランダムな文字列を生成する
+  ///
+  /// 参考: https://zenn.dev/makumaaku/articles/b8790d0c660e58
+  String _generateNonce([int length = 32]) {
+    const charset =
+        '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz';
+    final random = Random.secure();
+    final randomStr =
+        List.generate(length, (_) => charset[random.nextInt(charset.length)])
+            .join();
+    return randomStr;
   }
 
   /// ローカル通知を削除する

--- a/lib/feature/routine/state/local_notifications.dart
+++ b/lib/feature/routine/state/local_notifications.dart
@@ -52,6 +52,14 @@ extension FlutterLocalNotificationsPluginX on FlutterLocalNotificationsPlugin {
       );
     }
   }
+
+  /// ローカル通知を削除する
+  Future<void> delete(Routine routine) async {
+    final notifications = routine.toNotifications();
+    for (final notification in notifications) {
+      await cancel(notification.notificationId);
+    }
+  }
 }
 
 extension on Routine {

--- a/lib/feature/routine/state/local_notifications.dart
+++ b/lib/feature/routine/state/local_notifications.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:timezone/timezone.dart' as tz;
+import 'package:timezone/timezone.dart';
+
+import '../../../feature/routine/data/routine.dart';
+import 'routine.dart';
+
+part 'local_notifications.freezed.dart';
+
+@freezed
+class RoutineLocalNotification with _$RoutineLocalNotification {
+  const factory RoutineLocalNotification({
+    required int routineId,
+    required int? week,
+    required TZDateTime scheduledDate,
+    required DateTimeComponents? dateTimeComponents,
+  }) = _RoutineLocalNotification;
+  const RoutineLocalNotification._();
+
+  /// 通知ID
+  ///
+  /// 通知をキャンセルするために使用する。
+  /// 例えば、ルーティンIDが52で、月曜日の場合、通知IDは521になる（月〜日＝1〜7）。
+  /// 例えば、ルーティンIDが105で、曜日がない場合、通知IDは1050になる。
+  int get notificationId => routineId * 10 + (week ?? 0);
+}
+
+extension FlutterLocalNotificationsPluginX on FlutterLocalNotificationsPlugin {
+  /// ローカル通知を登録する
+  ///
+  /// 繰り返しがない場合は、1回だけ登録する。
+  /// 繰り返しがある場合は、曜日の数だけ登録する。
+  Future<void> register(Routine routine) async {
+    final notifications = routine.toNotifications();
+    for (final notification in notifications) {
+      await zonedSchedule(
+        notification.notificationId,
+        'ルーティン',
+        '時間になりました',
+        notification.scheduledDate,
+        NotificationDetails(
+          android: AndroidNotificationDetails(
+            'repeat-notification-${notification.notificationId}',
+            'repeat-notification',
+          ),
+        ),
+        uiLocalNotificationDateInterpretation:
+            UILocalNotificationDateInterpretation.absoluteTime,
+        androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+        matchDateTimeComponents: notification.dateTimeComponents,
+      );
+    }
+  }
+}
+
+extension on Routine {
+  List<RoutineLocalNotification> toNotifications() {
+    if (repetitionWeeks.isEmpty) {
+      return [
+        RoutineLocalNotification(
+          routineId: id,
+          week: null,
+          scheduledDate: tz.TZDateTime.from(firstNotificationDtime, tz.local),
+          dateTimeComponents: null,
+        ),
+      ];
+    }
+    return repetitionNotificationDtimes.map((dtime) {
+      return RoutineLocalNotification(
+        routineId: id,
+        week: dtime.weekday,
+        scheduledDate: tz.TZDateTime.from(dtime, tz.local),
+        dateTimeComponents: DateTimeComponents.dayOfWeekAndTime,
+      );
+    }).toList();
+  }
+}

--- a/lib/feature/routine/state/local_notifications.dart
+++ b/lib/feature/routine/state/local_notifications.dart
@@ -42,7 +42,7 @@ extension FlutterLocalNotificationsPluginX on FlutterLocalNotificationsPlugin {
       await zonedSchedule(
         notification.notificationId,
         'ルーティン',
-        '時間になりました',
+        routine.label,
         notification.scheduledDate,
         NotificationDetails(
           android: AndroidNotificationDetails(

--- a/lib/feature/routine/state/local_notifications.dart
+++ b/lib/feature/routine/state/local_notifications.dart
@@ -56,6 +56,11 @@ extension FlutterLocalNotificationsPluginX on FlutterLocalNotificationsPlugin {
             routine.title,
             playSound: routine.enableSound,
           ),
+          iOS: DarwinNotificationDetails(
+            presentAlert: true,
+            presentBanner: true,
+            presentSound: routine.enableSound,
+          ),
         ),
         uiLocalNotificationDateInterpretation:
             UILocalNotificationDateInterpretation.absoluteTime,

--- a/lib/feature/routine/state/local_notifications.dart
+++ b/lib/feature/routine/state/local_notifications.dart
@@ -24,6 +24,11 @@ class RoutineLocalNotification with _$RoutineLocalNotification {
   /// 例えば、ルーティンIDが52で、月曜日の場合、通知IDは521になる（月〜日＝1〜7）。
   /// 例えば、ルーティンIDが105で、曜日がない場合、通知IDは1050になる。
   int get notificationId => routineId * 10 + (week ?? 0);
+
+  /// 通知IDからルーティンIDを抽出する
+  static int extractRoutineId(int notificationId) {
+    return notificationId ~/ 10;
+  }
 }
 
 extension FlutterLocalNotificationsPluginX on FlutterLocalNotificationsPlugin {
@@ -62,7 +67,7 @@ extension FlutterLocalNotificationsPluginX on FlutterLocalNotificationsPlugin {
   }
 }
 
-extension on Routine {
+extension RoutineX on Routine {
   List<RoutineLocalNotification> toNotifications() {
     if (repetitionWeeks.isEmpty) {
       return [

--- a/lib/feature/routine/state/local_notifications.freezed.dart
+++ b/lib/feature/routine/state/local_notifications.freezed.dart
@@ -1,0 +1,209 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'local_notifications.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$RoutineLocalNotification {
+  int get routineId => throw _privateConstructorUsedError;
+  int? get week => throw _privateConstructorUsedError;
+  tz.TZDateTime get scheduledDate => throw _privateConstructorUsedError;
+  DateTimeComponents? get dateTimeComponents =>
+      throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $RoutineLocalNotificationCopyWith<RoutineLocalNotification> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RoutineLocalNotificationCopyWith<$Res> {
+  factory $RoutineLocalNotificationCopyWith(RoutineLocalNotification value,
+          $Res Function(RoutineLocalNotification) then) =
+      _$RoutineLocalNotificationCopyWithImpl<$Res, RoutineLocalNotification>;
+  @useResult
+  $Res call(
+      {int routineId,
+      int? week,
+      tz.TZDateTime scheduledDate,
+      DateTimeComponents? dateTimeComponents});
+}
+
+/// @nodoc
+class _$RoutineLocalNotificationCopyWithImpl<$Res,
+        $Val extends RoutineLocalNotification>
+    implements $RoutineLocalNotificationCopyWith<$Res> {
+  _$RoutineLocalNotificationCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? routineId = null,
+    Object? week = freezed,
+    Object? scheduledDate = null,
+    Object? dateTimeComponents = freezed,
+  }) {
+    return _then(_value.copyWith(
+      routineId: null == routineId
+          ? _value.routineId
+          : routineId // ignore: cast_nullable_to_non_nullable
+              as int,
+      week: freezed == week
+          ? _value.week
+          : week // ignore: cast_nullable_to_non_nullable
+              as int?,
+      scheduledDate: null == scheduledDate
+          ? _value.scheduledDate
+          : scheduledDate // ignore: cast_nullable_to_non_nullable
+              as tz.TZDateTime,
+      dateTimeComponents: freezed == dateTimeComponents
+          ? _value.dateTimeComponents
+          : dateTimeComponents // ignore: cast_nullable_to_non_nullable
+              as DateTimeComponents?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$RoutineLocalNotificationImplCopyWith<$Res>
+    implements $RoutineLocalNotificationCopyWith<$Res> {
+  factory _$$RoutineLocalNotificationImplCopyWith(
+          _$RoutineLocalNotificationImpl value,
+          $Res Function(_$RoutineLocalNotificationImpl) then) =
+      __$$RoutineLocalNotificationImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int routineId,
+      int? week,
+      tz.TZDateTime scheduledDate,
+      DateTimeComponents? dateTimeComponents});
+}
+
+/// @nodoc
+class __$$RoutineLocalNotificationImplCopyWithImpl<$Res>
+    extends _$RoutineLocalNotificationCopyWithImpl<$Res,
+        _$RoutineLocalNotificationImpl>
+    implements _$$RoutineLocalNotificationImplCopyWith<$Res> {
+  __$$RoutineLocalNotificationImplCopyWithImpl(
+      _$RoutineLocalNotificationImpl _value,
+      $Res Function(_$RoutineLocalNotificationImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? routineId = null,
+    Object? week = freezed,
+    Object? scheduledDate = null,
+    Object? dateTimeComponents = freezed,
+  }) {
+    return _then(_$RoutineLocalNotificationImpl(
+      routineId: null == routineId
+          ? _value.routineId
+          : routineId // ignore: cast_nullable_to_non_nullable
+              as int,
+      week: freezed == week
+          ? _value.week
+          : week // ignore: cast_nullable_to_non_nullable
+              as int?,
+      scheduledDate: null == scheduledDate
+          ? _value.scheduledDate
+          : scheduledDate // ignore: cast_nullable_to_non_nullable
+              as tz.TZDateTime,
+      dateTimeComponents: freezed == dateTimeComponents
+          ? _value.dateTimeComponents
+          : dateTimeComponents // ignore: cast_nullable_to_non_nullable
+              as DateTimeComponents?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$RoutineLocalNotificationImpl extends _RoutineLocalNotification {
+  const _$RoutineLocalNotificationImpl(
+      {required this.routineId,
+      required this.week,
+      required this.scheduledDate,
+      required this.dateTimeComponents})
+      : super._();
+
+  @override
+  final int routineId;
+  @override
+  final int? week;
+  @override
+  final tz.TZDateTime scheduledDate;
+  @override
+  final DateTimeComponents? dateTimeComponents;
+
+  @override
+  String toString() {
+    return 'RoutineLocalNotification(routineId: $routineId, week: $week, scheduledDate: $scheduledDate, dateTimeComponents: $dateTimeComponents)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RoutineLocalNotificationImpl &&
+            (identical(other.routineId, routineId) ||
+                other.routineId == routineId) &&
+            (identical(other.week, week) || other.week == week) &&
+            (identical(other.scheduledDate, scheduledDate) ||
+                other.scheduledDate == scheduledDate) &&
+            (identical(other.dateTimeComponents, dateTimeComponents) ||
+                other.dateTimeComponents == dateTimeComponents));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, routineId, week, scheduledDate, dateTimeComponents);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RoutineLocalNotificationImplCopyWith<_$RoutineLocalNotificationImpl>
+      get copyWith => __$$RoutineLocalNotificationImplCopyWithImpl<
+          _$RoutineLocalNotificationImpl>(this, _$identity);
+}
+
+abstract class _RoutineLocalNotification extends RoutineLocalNotification {
+  const factory _RoutineLocalNotification(
+          {required final int routineId,
+          required final int? week,
+          required final tz.TZDateTime scheduledDate,
+          required final DateTimeComponents? dateTimeComponents}) =
+      _$RoutineLocalNotificationImpl;
+  const _RoutineLocalNotification._() : super._();
+
+  @override
+  int get routineId;
+  @override
+  int? get week;
+  @override
+  tz.TZDateTime get scheduledDate;
+  @override
+  DateTimeComponents? get dateTimeComponents;
+  @override
+  @JsonKey(ignore: true)
+  _$$RoutineLocalNotificationImplCopyWith<_$RoutineLocalNotificationImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/feature/routine/state/routine.dart
+++ b/lib/feature/routine/state/routine.dart
@@ -10,7 +10,7 @@ part 'routine.g.dart';
 extension RoutineX on Routine {
   TimeOfDay get notificationTimeOfDay => TimeOfDay(
         hour: notificationTime ~/ 3600,
-        minute: notificationTime % 60,
+        minute: (notificationTime % 3600) ~/ 60,
       );
 }
 

--- a/lib/feature/routine/state/routine.dart
+++ b/lib/feature/routine/state/routine.dart
@@ -42,6 +42,13 @@ extension RoutineX on Routine {
       return dtime;
     }).toList();
   }
+
+  String get title {
+    if (repetitionWeeks.isEmpty) {
+      return label;
+    }
+    return '$label、 ${repetitionWeeks.title}';
+  }
 }
 
 extension RepetitionWeekX on RepetitionWeek {

--- a/lib/feature/routine/state/routine.dart
+++ b/lib/feature/routine/state/routine.dart
@@ -12,6 +12,36 @@ extension RoutineX on Routine {
         hour: notificationTime ~/ 3600,
         minute: (notificationTime % 3600) ~/ 60,
       );
+
+  /// 最初の通知日時
+  DateTime get firstNotificationDtime {
+    final now = DateTime.now();
+    var dtime = DateTime(
+      now.year,
+      now.month,
+      now.day,
+      notificationTimeOfDay.hour,
+      notificationTimeOfDay.minute,
+    );
+    if (dtime.isBefore(now)) {
+      // 過去の時間の場合は翌日にする
+      dtime = dtime.add(const Duration(days: 1));
+    }
+    return dtime;
+  }
+
+  /// 繰り返し通知の日時
+  List<DateTime> get repetitionNotificationDtimes {
+    final firstNotificationDtime = this.firstNotificationDtime;
+    return repetitionWeeks.map((e) {
+      var dtime = firstNotificationDtime;
+      // 曜日が一致するまで進める
+      while (dtime.weekday != e.index + 1) {
+        dtime = dtime.add(const Duration(days: 1));
+      }
+      return dtime;
+    }).toList();
+  }
 }
 
 extension RepetitionWeekX on RepetitionWeek {

--- a/lib/feature/routine/state/routine_form_values.dart
+++ b/lib/feature/routine/state/routine_form_values.dart
@@ -16,7 +16,6 @@ class RoutineFormValues with _$RoutineFormValues {
     required TimeOfDay notificationTimeOfDay,
     @Default(<RepetitionWeek>[]) List<RepetitionWeek> repetitionWeeks,
     @Default(true) bool enableSound,
-    @Default(true) bool enablePush,
   }) = _RoutineFormValues;
   const RoutineFormValues._();
 
@@ -24,7 +23,6 @@ class RoutineFormValues with _$RoutineFormValues {
         notificationTimeOfDay: entity.notificationTimeOfDay,
         repetitionWeeks: entity.repetitionWeeks,
         enableSound: entity.enableSound,
-        enablePush: entity.enablePush,
       );
 
   /// エンティティに変換する
@@ -32,8 +30,7 @@ class RoutineFormValues with _$RoutineFormValues {
     ..notificationTime =
         notificationTimeOfDay.hour * 3600 + notificationTimeOfDay.minute * 60
     ..repetitionWeeks = repetitionWeeks
-    ..enableSound = enableSound
-    ..enablePush = enablePush;
+    ..enableSound = enableSound;
 }
 
 @riverpod
@@ -89,10 +86,5 @@ mixin _RoutineFormValuesNotifier on AutoDisposeNotifier<RoutineFormValues> {
   // ignore: avoid_positional_boolean_parameters
   void updateEnableSound(bool value) {
     state = state.copyWith(enableSound: value);
-  }
-
-  // ignore: avoid_positional_boolean_parameters
-  void updateEnablePush(bool value) {
-    state = state.copyWith(enablePush: value);
   }
 }

--- a/lib/feature/routine/state/routine_form_values.dart
+++ b/lib/feature/routine/state/routine_form_values.dart
@@ -16,6 +16,7 @@ class RoutineFormValues with _$RoutineFormValues {
     required TimeOfDay notificationTimeOfDay,
     @Default(<RepetitionWeek>[]) List<RepetitionWeek> repetitionWeeks,
     @Default(true) bool enableSound,
+    @Default('') String label,
   }) = _RoutineFormValues;
   const RoutineFormValues._();
 
@@ -23,6 +24,7 @@ class RoutineFormValues with _$RoutineFormValues {
         notificationTimeOfDay: entity.notificationTimeOfDay,
         repetitionWeeks: entity.repetitionWeeks,
         enableSound: entity.enableSound,
+        label: entity.label,
       );
 
   /// エンティティに変換する
@@ -30,7 +32,8 @@ class RoutineFormValues with _$RoutineFormValues {
     ..notificationTime =
         notificationTimeOfDay.hour * 3600 + notificationTimeOfDay.minute * 60
     ..repetitionWeeks = repetitionWeeks
-    ..enableSound = enableSound;
+    ..enableSound = enableSound
+    ..label = label.isEmpty ? 'アラーム' : label;
 }
 
 @riverpod
@@ -86,5 +89,9 @@ mixin _RoutineFormValuesNotifier on AutoDisposeNotifier<RoutineFormValues> {
   // ignore: avoid_positional_boolean_parameters
   void updateEnableSound(bool value) {
     state = state.copyWith(enableSound: value);
+  }
+
+  void updateLabel(String value) {
+    state = state.copyWith(label: value);
   }
 }

--- a/lib/feature/routine/state/routine_form_values.dart
+++ b/lib/feature/routine/state/routine_form_values.dart
@@ -13,7 +13,7 @@ part 'routine_form_values.g.dart';
 @freezed
 class RoutineFormValues with _$RoutineFormValues {
   const factory RoutineFormValues({
-    @Default(TimeOfDay(hour: 7, minute: 0)) TimeOfDay notificationTimeOfDay,
+    required TimeOfDay notificationTimeOfDay,
     @Default(<RepetitionWeek>[]) List<RepetitionWeek> repetitionWeeks,
     @Default(true) bool enableSound,
     @Default(true) bool enablePush,
@@ -42,7 +42,9 @@ class AdditionalRoutineFormValuesNotifier
     with _RoutineFormValuesNotifier {
   @override
   RoutineFormValues build() {
-    return const RoutineFormValues();
+    return RoutineFormValues(
+      notificationTimeOfDay: TimeOfDay.now(),
+    );
   }
 }
 

--- a/lib/feature/routine/state/routine_form_values.freezed.dart
+++ b/lib/feature/routine/state/routine_form_values.freezed.dart
@@ -20,6 +20,7 @@ mixin _$RoutineFormValues {
   List<RepetitionWeek> get repetitionWeeks =>
       throw _privateConstructorUsedError;
   bool get enableSound => throw _privateConstructorUsedError;
+  String get label => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $RoutineFormValuesCopyWith<RoutineFormValues> get copyWith =>
@@ -35,7 +36,8 @@ abstract class $RoutineFormValuesCopyWith<$Res> {
   $Res call(
       {TimeOfDay notificationTimeOfDay,
       List<RepetitionWeek> repetitionWeeks,
-      bool enableSound});
+      bool enableSound,
+      String label});
 }
 
 /// @nodoc
@@ -54,6 +56,7 @@ class _$RoutineFormValuesCopyWithImpl<$Res, $Val extends RoutineFormValues>
     Object? notificationTimeOfDay = null,
     Object? repetitionWeeks = null,
     Object? enableSound = null,
+    Object? label = null,
   }) {
     return _then(_value.copyWith(
       notificationTimeOfDay: null == notificationTimeOfDay
@@ -68,6 +71,10 @@ class _$RoutineFormValuesCopyWithImpl<$Res, $Val extends RoutineFormValues>
           ? _value.enableSound
           : enableSound // ignore: cast_nullable_to_non_nullable
               as bool,
+      label: null == label
+          ? _value.label
+          : label // ignore: cast_nullable_to_non_nullable
+              as String,
     ) as $Val);
   }
 }
@@ -83,7 +90,8 @@ abstract class _$$RoutineFormValuesImplCopyWith<$Res>
   $Res call(
       {TimeOfDay notificationTimeOfDay,
       List<RepetitionWeek> repetitionWeeks,
-      bool enableSound});
+      bool enableSound,
+      String label});
 }
 
 /// @nodoc
@@ -100,6 +108,7 @@ class __$$RoutineFormValuesImplCopyWithImpl<$Res>
     Object? notificationTimeOfDay = null,
     Object? repetitionWeeks = null,
     Object? enableSound = null,
+    Object? label = null,
   }) {
     return _then(_$RoutineFormValuesImpl(
       notificationTimeOfDay: null == notificationTimeOfDay
@@ -114,6 +123,10 @@ class __$$RoutineFormValuesImplCopyWithImpl<$Res>
           ? _value.enableSound
           : enableSound // ignore: cast_nullable_to_non_nullable
               as bool,
+      label: null == label
+          ? _value.label
+          : label // ignore: cast_nullable_to_non_nullable
+              as String,
     ));
   }
 }
@@ -124,7 +137,8 @@ class _$RoutineFormValuesImpl extends _RoutineFormValues {
   const _$RoutineFormValuesImpl(
       {required this.notificationTimeOfDay,
       final List<RepetitionWeek> repetitionWeeks = const <RepetitionWeek>[],
-      this.enableSound = true})
+      this.enableSound = true,
+      this.label = ''})
       : _repetitionWeeks = repetitionWeeks,
         super._();
 
@@ -142,10 +156,13 @@ class _$RoutineFormValuesImpl extends _RoutineFormValues {
   @override
   @JsonKey()
   final bool enableSound;
+  @override
+  @JsonKey()
+  final String label;
 
   @override
   String toString() {
-    return 'RoutineFormValues(notificationTimeOfDay: $notificationTimeOfDay, repetitionWeeks: $repetitionWeeks, enableSound: $enableSound)';
+    return 'RoutineFormValues(notificationTimeOfDay: $notificationTimeOfDay, repetitionWeeks: $repetitionWeeks, enableSound: $enableSound, label: $label)';
   }
 
   @override
@@ -158,12 +175,17 @@ class _$RoutineFormValuesImpl extends _RoutineFormValues {
             const DeepCollectionEquality()
                 .equals(other._repetitionWeeks, _repetitionWeeks) &&
             (identical(other.enableSound, enableSound) ||
-                other.enableSound == enableSound));
+                other.enableSound == enableSound) &&
+            (identical(other.label, label) || other.label == label));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, notificationTimeOfDay,
-      const DeepCollectionEquality().hash(_repetitionWeeks), enableSound);
+  int get hashCode => Object.hash(
+      runtimeType,
+      notificationTimeOfDay,
+      const DeepCollectionEquality().hash(_repetitionWeeks),
+      enableSound,
+      label);
 
   @JsonKey(ignore: true)
   @override
@@ -177,7 +199,8 @@ abstract class _RoutineFormValues extends RoutineFormValues {
   const factory _RoutineFormValues(
       {required final TimeOfDay notificationTimeOfDay,
       final List<RepetitionWeek> repetitionWeeks,
-      final bool enableSound}) = _$RoutineFormValuesImpl;
+      final bool enableSound,
+      final String label}) = _$RoutineFormValuesImpl;
   const _RoutineFormValues._() : super._();
 
   @override
@@ -186,6 +209,8 @@ abstract class _RoutineFormValues extends RoutineFormValues {
   List<RepetitionWeek> get repetitionWeeks;
   @override
   bool get enableSound;
+  @override
+  String get label;
   @override
   @JsonKey(ignore: true)
   _$$RoutineFormValuesImplCopyWith<_$RoutineFormValuesImpl> get copyWith =>

--- a/lib/feature/routine/state/routine_form_values.freezed.dart
+++ b/lib/feature/routine/state/routine_form_values.freezed.dart
@@ -135,7 +135,7 @@ class __$$RoutineFormValuesImplCopyWithImpl<$Res>
 
 class _$RoutineFormValuesImpl extends _RoutineFormValues {
   const _$RoutineFormValuesImpl(
-      {this.notificationTimeOfDay = const TimeOfDay(hour: 7, minute: 0),
+      {required this.notificationTimeOfDay,
       final List<RepetitionWeek> repetitionWeeks = const <RepetitionWeek>[],
       this.enableSound = true,
       this.enablePush = true})
@@ -143,7 +143,6 @@ class _$RoutineFormValuesImpl extends _RoutineFormValues {
         super._();
 
   @override
-  @JsonKey()
   final TimeOfDay notificationTimeOfDay;
   final List<RepetitionWeek> _repetitionWeeks;
   @override
@@ -199,7 +198,7 @@ class _$RoutineFormValuesImpl extends _RoutineFormValues {
 
 abstract class _RoutineFormValues extends RoutineFormValues {
   const factory _RoutineFormValues(
-      {final TimeOfDay notificationTimeOfDay,
+      {required final TimeOfDay notificationTimeOfDay,
       final List<RepetitionWeek> repetitionWeeks,
       final bool enableSound,
       final bool enablePush}) = _$RoutineFormValuesImpl;

--- a/lib/feature/routine/state/routine_form_values.freezed.dart
+++ b/lib/feature/routine/state/routine_form_values.freezed.dart
@@ -20,7 +20,6 @@ mixin _$RoutineFormValues {
   List<RepetitionWeek> get repetitionWeeks =>
       throw _privateConstructorUsedError;
   bool get enableSound => throw _privateConstructorUsedError;
-  bool get enablePush => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $RoutineFormValuesCopyWith<RoutineFormValues> get copyWith =>
@@ -36,8 +35,7 @@ abstract class $RoutineFormValuesCopyWith<$Res> {
   $Res call(
       {TimeOfDay notificationTimeOfDay,
       List<RepetitionWeek> repetitionWeeks,
-      bool enableSound,
-      bool enablePush});
+      bool enableSound});
 }
 
 /// @nodoc
@@ -56,7 +54,6 @@ class _$RoutineFormValuesCopyWithImpl<$Res, $Val extends RoutineFormValues>
     Object? notificationTimeOfDay = null,
     Object? repetitionWeeks = null,
     Object? enableSound = null,
-    Object? enablePush = null,
   }) {
     return _then(_value.copyWith(
       notificationTimeOfDay: null == notificationTimeOfDay
@@ -70,10 +67,6 @@ class _$RoutineFormValuesCopyWithImpl<$Res, $Val extends RoutineFormValues>
       enableSound: null == enableSound
           ? _value.enableSound
           : enableSound // ignore: cast_nullable_to_non_nullable
-              as bool,
-      enablePush: null == enablePush
-          ? _value.enablePush
-          : enablePush // ignore: cast_nullable_to_non_nullable
               as bool,
     ) as $Val);
   }
@@ -90,8 +83,7 @@ abstract class _$$RoutineFormValuesImplCopyWith<$Res>
   $Res call(
       {TimeOfDay notificationTimeOfDay,
       List<RepetitionWeek> repetitionWeeks,
-      bool enableSound,
-      bool enablePush});
+      bool enableSound});
 }
 
 /// @nodoc
@@ -108,7 +100,6 @@ class __$$RoutineFormValuesImplCopyWithImpl<$Res>
     Object? notificationTimeOfDay = null,
     Object? repetitionWeeks = null,
     Object? enableSound = null,
-    Object? enablePush = null,
   }) {
     return _then(_$RoutineFormValuesImpl(
       notificationTimeOfDay: null == notificationTimeOfDay
@@ -123,10 +114,6 @@ class __$$RoutineFormValuesImplCopyWithImpl<$Res>
           ? _value.enableSound
           : enableSound // ignore: cast_nullable_to_non_nullable
               as bool,
-      enablePush: null == enablePush
-          ? _value.enablePush
-          : enablePush // ignore: cast_nullable_to_non_nullable
-              as bool,
     ));
   }
 }
@@ -137,8 +124,7 @@ class _$RoutineFormValuesImpl extends _RoutineFormValues {
   const _$RoutineFormValuesImpl(
       {required this.notificationTimeOfDay,
       final List<RepetitionWeek> repetitionWeeks = const <RepetitionWeek>[],
-      this.enableSound = true,
-      this.enablePush = true})
+      this.enableSound = true})
       : _repetitionWeeks = repetitionWeeks,
         super._();
 
@@ -156,13 +142,10 @@ class _$RoutineFormValuesImpl extends _RoutineFormValues {
   @override
   @JsonKey()
   final bool enableSound;
-  @override
-  @JsonKey()
-  final bool enablePush;
 
   @override
   String toString() {
-    return 'RoutineFormValues(notificationTimeOfDay: $notificationTimeOfDay, repetitionWeeks: $repetitionWeeks, enableSound: $enableSound, enablePush: $enablePush)';
+    return 'RoutineFormValues(notificationTimeOfDay: $notificationTimeOfDay, repetitionWeeks: $repetitionWeeks, enableSound: $enableSound)';
   }
 
   @override
@@ -175,18 +158,12 @@ class _$RoutineFormValuesImpl extends _RoutineFormValues {
             const DeepCollectionEquality()
                 .equals(other._repetitionWeeks, _repetitionWeeks) &&
             (identical(other.enableSound, enableSound) ||
-                other.enableSound == enableSound) &&
-            (identical(other.enablePush, enablePush) ||
-                other.enablePush == enablePush));
+                other.enableSound == enableSound));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      notificationTimeOfDay,
-      const DeepCollectionEquality().hash(_repetitionWeeks),
-      enableSound,
-      enablePush);
+  int get hashCode => Object.hash(runtimeType, notificationTimeOfDay,
+      const DeepCollectionEquality().hash(_repetitionWeeks), enableSound);
 
   @JsonKey(ignore: true)
   @override
@@ -200,8 +177,7 @@ abstract class _RoutineFormValues extends RoutineFormValues {
   const factory _RoutineFormValues(
       {required final TimeOfDay notificationTimeOfDay,
       final List<RepetitionWeek> repetitionWeeks,
-      final bool enableSound,
-      final bool enablePush}) = _$RoutineFormValuesImpl;
+      final bool enableSound}) = _$RoutineFormValuesImpl;
   const _RoutineFormValues._() : super._();
 
   @override
@@ -210,8 +186,6 @@ abstract class _RoutineFormValues extends RoutineFormValues {
   List<RepetitionWeek> get repetitionWeeks;
   @override
   bool get enableSound;
-  @override
-  bool get enablePush;
   @override
   @JsonKey(ignore: true)
   _$$RoutineFormValuesImplCopyWith<_$RoutineFormValuesImpl> get copyWith =>

--- a/lib/feature/routine/state/routine_form_values.g.dart
+++ b/lib/feature/routine/state/routine_form_values.g.dart
@@ -7,7 +7,7 @@ part of 'routine_form_values.dart';
 // **************************************************************************
 
 String _$additionalRoutineFormValuesNotifierHash() =>
-    r'e3d99c6e32d1791d37028fc88bb67403f052935e';
+    r'0dd43413bdccecbd577950177e817b83d30d6f7b';
 
 /// See also [AdditionalRoutineFormValuesNotifier].
 @ProviderFor(AdditionalRoutineFormValuesNotifier)

--- a/lib/feature/routine/ui/component/label_text_field.dart
+++ b/lib/feature/routine/ui/component/label_text_field.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/ui/component/material.dart';
+
+class LabelTextField extends ConsumerWidget {
+  const LabelTextField({
+    super.key,
+    required this.label,
+    required this.onChanged,
+  });
+
+  final String label;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return TextField(
+      controller: TextEditingController(text: label),
+      decoration: const InputDecoration(
+        hintText: 'アラーム',
+        border: InputBorder.none,
+        counterText: '',
+      ),
+      textAlign: TextAlign.end,
+      style: TextStyle(
+        color: context.outline,
+      ),
+      maxLength: 20,
+      onChanged: onChanged,
+    );
+  }
+}

--- a/lib/feature/routine/ui/routine_add_page.dart
+++ b/lib/feature/routine/ui/routine_add_page.dart
@@ -8,6 +8,7 @@ import '../../../router/router.dart';
 import '../state/routine.dart';
 import '../state/routine_form_values.dart';
 import 'component/add_routine.dart';
+import 'component/label_text_field.dart';
 
 @RoutePage()
 class RoutineAddPage extends StatelessWidget {
@@ -44,6 +45,7 @@ class _Body extends StatelessWidget {
           ),
           Gap(32),
           _RepetitionListTile(),
+          _UpdateLabelListTile(),
           _EnableSoundListTile(),
         ],
       ),
@@ -108,6 +110,35 @@ class _RepetitionListTile extends ConsumerWidget {
         ],
       ),
       trailing: const Icon(Icons.navigate_next),
+    );
+  }
+}
+
+class _UpdateLabelListTile extends ConsumerWidget {
+  const _UpdateLabelListTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final label = ref.watch(
+      additionalRoutineFormValuesNotifierProvider
+          .select((value) => value.label),
+    );
+    return ListTile(
+      title: Row(
+        children: [
+          const Text('ラベル'),
+          Expanded(
+            child: LabelTextField(
+              label: label,
+              onChanged: (value) {
+                ref
+                    .read(additionalRoutineFormValuesNotifierProvider.notifier)
+                    .updateLabel(value);
+              },
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/feature/routine/ui/routine_add_page.dart
+++ b/lib/feature/routine/ui/routine_add_page.dart
@@ -45,7 +45,6 @@ class _Body extends StatelessWidget {
           Gap(32),
           _RepetitionListTile(),
           _EnableSoundListTile(),
-          _EnablePushListTile(),
         ],
       ),
     );
@@ -129,27 +128,6 @@ class _EnableSoundListTile extends ConsumerWidget {
         ref
             .read(additionalRoutineFormValuesNotifierProvider.notifier)
             .updateEnableSound(value);
-      },
-    );
-  }
-}
-
-class _EnablePushListTile extends ConsumerWidget {
-  const _EnablePushListTile();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final enablePush = ref.watch(
-      additionalRoutineFormValuesNotifierProvider
-          .select((value) => value.enablePush),
-    );
-    return SwitchListTile(
-      title: const Text('プッシュ通知'),
-      value: enablePush,
-      onChanged: (value) {
-        ref
-            .read(additionalRoutineFormValuesNotifierProvider.notifier)
-            .updateEnablePush(value);
       },
     );
   }

--- a/lib/feature/routine/ui/routine_index_page.dart
+++ b/lib/feature/routine/ui/routine_index_page.dart
@@ -95,7 +95,13 @@ class _ListTile extends ConsumerWidget {
             color: routine.state ? null : context.outline,
           ),
         ),
-        subtitle: Text('繰り返し：${routine.repetitionWeeks.title}'),
+        subtitle: Wrap(
+          children: [
+            Text(routine.label),
+            if (routine.repetitionWeeks.isNotEmpty)
+              Text('、${routine.repetitionWeeks.title}'),
+          ],
+        ),
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         trailing: Switch(
           value: routine.state,

--- a/lib/feature/routine/ui/routine_index_page.dart
+++ b/lib/feature/routine/ui/routine_index_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import '../../../core/ui/component/material.dart';
 import '../../../core/ui/component/riverpod.dart';
 import '../../../router/router.dart';
+import '../../debug/ui/component/navigate_debug_button.dart';
 import '../data/routine.dart';
 import '../state/routine.dart';
 import '../use_case/delete_routine.dart';
@@ -22,6 +23,7 @@ class RoutineIndexPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('ルーティン'),
         actions: const [
+          NavigateDebugButton(),
           NavigateRoutineAddPageButton(),
         ],
       ),

--- a/lib/feature/routine/ui/routine_index_page.dart
+++ b/lib/feature/routine/ui/routine_index_page.dart
@@ -95,13 +95,7 @@ class _ListTile extends ConsumerWidget {
             color: routine.state ? null : context.outline,
           ),
         ),
-        subtitle: Wrap(
-          children: [
-            Text(routine.label),
-            if (routine.repetitionWeeks.isNotEmpty)
-              Text('、${routine.repetitionWeeks.title}'),
-          ],
-        ),
+        subtitle: Text(routine.title),
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         trailing: Switch(
           value: routine.state,

--- a/lib/feature/routine/ui/routine_update_page.dart
+++ b/lib/feature/routine/ui/routine_update_page.dart
@@ -51,7 +51,6 @@ class _Body extends StatelessWidget {
           Gap(32),
           _RepetitionListTile(),
           _EnableSoundListTile(),
-          _EnablePushListTile(),
           Gap(32),
           DeleteCurrentRoutineButton(),
           Gap(32),
@@ -140,27 +139,6 @@ class _EnableSoundListTile extends ConsumerWidget {
         ref
             .read(updatedRoutineFormValuesNotifierProvider.notifier)
             .updateEnableSound(value);
-      },
-    );
-  }
-}
-
-class _EnablePushListTile extends ConsumerWidget {
-  const _EnablePushListTile();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final enablePush = ref.watch(
-      updatedRoutineFormValuesNotifierProvider
-          .select((value) => value.enablePush),
-    );
-    return SwitchListTile(
-      title: const Text('プッシュ通知'),
-      value: enablePush,
-      onChanged: (value) {
-        ref
-            .read(updatedRoutineFormValuesNotifierProvider.notifier)
-            .updateEnablePush(value);
       },
     );
   }

--- a/lib/feature/routine/ui/routine_update_page.dart
+++ b/lib/feature/routine/ui/routine_update_page.dart
@@ -72,7 +72,17 @@ class _NotificationTimeButton extends ConsumerWidget {
       ),
     );
     return TextButton(
-      onPressed: () => context.navigateTo(RepetitionUpdateRoute()),
+      onPressed: () async {
+        final time = await showTimePicker(
+          context: context,
+          initialTime: notificationTimeOfDay,
+        );
+        if (time != null) {
+          ref
+              .read(updatedRoutineFormValuesNotifierProvider.notifier)
+              .updateNotificationTime(time);
+        }
+      },
       child: Text(
         notificationTimeOfDay.format(context),
         style: const TextStyle(

--- a/lib/feature/routine/ui/routine_update_page.dart
+++ b/lib/feature/routine/ui/routine_update_page.dart
@@ -8,6 +8,7 @@ import '../../../router/router.dart';
 import '../state/routine.dart';
 import '../state/routine_form_values.dart';
 import 'component/delete_routine.dart';
+import 'component/label_text_field.dart';
 import 'component/update_routine.dart';
 
 @RoutePage()
@@ -50,6 +51,7 @@ class _Body extends StatelessWidget {
           ),
           Gap(32),
           _RepetitionListTile(),
+          _UpdateLabelListTile(),
           _EnableSoundListTile(),
           Gap(32),
           DeleteCurrentRoutineButton(),
@@ -118,6 +120,34 @@ class _RepetitionListTile extends ConsumerWidget {
         ],
       ),
       trailing: const Icon(Icons.navigate_next),
+    );
+  }
+}
+
+class _UpdateLabelListTile extends ConsumerWidget {
+  const _UpdateLabelListTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final label = ref.watch(
+      updatedRoutineFormValuesNotifierProvider.select((value) => value.label),
+    );
+    return ListTile(
+      title: Row(
+        children: [
+          const Text('ラベル'),
+          Expanded(
+            child: LabelTextField(
+              label: label,
+              onChanged: (value) {
+                ref
+                    .read(updatedRoutineFormValuesNotifierProvider.notifier)
+                    .updateLabel(value);
+              },
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/feature/routine/use_case/add_routine.dart
+++ b/lib/feature/routine/use_case/add_routine.dart
@@ -1,7 +1,9 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/data/isar/isar.dart';
+import '../../../core/data/local_notifications/local_notifications.dart';
 import '../data/routine.dart';
+import '../state/local_notifications.dart';
 import '../state/routine_form_values.dart';
 
 part 'add_routine.g.dart';
@@ -21,7 +23,9 @@ class AddRoutineUseCase extends _$AddRoutineUseCase {
       await isar.writeTxn(() async {
         final formValues =
             ref.read(additionalRoutineFormValuesNotifierProvider);
-        await isar.routines.put(formValues.toEntity());
+        final entity = formValues.toEntity();
+        await isar.routines.put(entity);
+        await ref.read(localNotificationsPluginProvider).register(entity);
       });
     });
   }

--- a/lib/feature/routine/use_case/delete_routine.dart
+++ b/lib/feature/routine/use_case/delete_routine.dart
@@ -1,7 +1,9 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/data/isar/isar.dart';
+import '../../../core/data/local_notifications/local_notifications.dart';
 import '../data/routine.dart';
+import '../state/local_notifications.dart';
 
 part 'delete_routine.g.dart';
 
@@ -19,6 +21,7 @@ class DeleteRoutineUseCase extends _$DeleteRoutineUseCase {
       final isar = ref.read(isarProvider);
       await isar.writeTxn(() async {
         await isar.routines.delete(routine.id);
+        await ref.read(localNotificationsPluginProvider).delete(routine);
       });
     });
   }

--- a/lib/feature/routine/use_case/delete_routine.g.dart
+++ b/lib/feature/routine/use_case/delete_routine.g.dart
@@ -7,7 +7,7 @@ part of 'delete_routine.dart';
 // **************************************************************************
 
 String _$deleteRoutineUseCaseHash() =>
-    r'cafa19dac87720db040ead9cba6837ae427fb326';
+    r'6136b5284b78d29c119573330067dd8f6c041c2b';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/routine/use_case/update_routine.dart
+++ b/lib/feature/routine/use_case/update_routine.dart
@@ -1,8 +1,10 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/data/isar/isar.dart';
+import '../../../core/data/local_notifications/local_notifications.dart';
 import '../data/routine.dart';
 import '../state/current_routine.dart';
+import '../state/local_notifications.dart';
 import '../state/routine_form_values.dart';
 
 part 'update_routine.g.dart';
@@ -20,12 +22,18 @@ class UpdateRoutineUseCase extends _$UpdateRoutineUseCase {
     state = await AsyncValue.guard(() async {
       final isar = ref.read(isarProvider);
       await isar.writeTxn(() async {
-        final routine = ref.read(currentRoutineProvider);
-        if (routine == null) {
+        final oldEntity = ref.read(currentRoutineProvider);
+        if (oldEntity == null) {
           throw StateError('Routine is not found');
         }
         final formValues = ref.read(updatedRoutineFormValuesNotifierProvider);
-        await isar.routines.put(formValues.toEntity(routine));
+        final newEntity = formValues.toEntity(oldEntity);
+        await isar.routines.put(newEntity);
+
+        final localNotificationsPlugin =
+            ref.read(localNotificationsPluginProvider);
+        await localNotificationsPlugin.delete(oldEntity);
+        await localNotificationsPlugin.register(newEntity);
       });
     });
   }

--- a/lib/feature/routine/use_case/update_routine.g.dart
+++ b/lib/feature/routine/use_case/update_routine.g.dart
@@ -7,7 +7,7 @@ part of 'update_routine.dart';
 // **************************************************************************
 
 String _$updateRoutineUseCaseHash() =>
-    r'26ce1c04d8d2578094e9819fe2bf06922fdd755b';
+    r'47a65474172e3cf323dfb5a5bc3549f5f8f69d06';
 
 /// See also [UpdateRoutineUseCase].
 @ProviderFor(UpdateRoutineUseCase)

--- a/lib/feature/routine/use_case/update_routine_state.dart
+++ b/lib/feature/routine/use_case/update_routine_state.dart
@@ -1,7 +1,9 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/data/isar/isar.dart';
+import '../../../core/data/local_notifications/local_notifications.dart';
 import '../data/routine.dart';
+import '../state/local_notifications.dart';
 
 part 'update_routine_state.g.dart';
 
@@ -21,6 +23,14 @@ class UpdateRoutineStateUseCase extends _$UpdateRoutineStateUseCase {
       await isar.writeTxn(() async {
         routine.state = value;
         await isar.routines.put(routine);
+
+        final localNotificationsPlugin =
+            ref.read(localNotificationsPluginProvider);
+        if (value) {
+          await localNotificationsPlugin.register(routine);
+        } else {
+          await localNotificationsPlugin.delete(routine);
+        }
       });
     });
   }

--- a/lib/feature/routine/use_case/update_routine_state.g.dart
+++ b/lib/feature/routine/use_case/update_routine_state.g.dart
@@ -7,7 +7,7 @@ part of 'update_routine_state.dart';
 // **************************************************************************
 
 String _$updateRoutineStateUseCaseHash() =>
-    r'0c2b90c300cf52ed7458af837669e211aab94dce';
+    r'df93454d1e31af2969912fd99034b1738d017d6b';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,12 +2,17 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 
 import 'app.dart';
 import 'core/data/isar/isar.dart';
+import 'core/data/local_notifications/local_notifications.dart';
 import 'feature/routine/data/routine.dart';
 import 'util/logger.dart';
 import 'util/provider_logger.dart';
@@ -27,12 +32,31 @@ Future<void> main() async {
     directory: dir.path,
   );
 
+  // TimeZone for local notifications
+  tz.initializeTimeZones();
+  final timeZoneName = await FlutterTimezone.getLocalTimezone();
+  logger.i('$_logPrefix timeZoneName = $timeZoneName');
+  tz.setLocalLocation(tz.getLocation(timeZoneName));
+
+  // Local notifications plugin
+  final localNotificationsPlugin = FlutterLocalNotificationsPlugin();
+
+  // アプリがキルされた状態でローカル通知をタップしたときはペイロードがある
+  final details =
+      await localNotificationsPlugin.getNotificationAppLaunchDetails();
+  logger.i(
+    '$_logPrefix notification payload = '
+    '${details?.notificationResponse?.payload}',
+  );
+
   logger.i('$_logPrefix runApp() START');
 
   runApp(
     ProviderScope(
       overrides: [
         isarProvider.overrideWithValue(isar),
+        localNotificationsPluginProvider
+            .overrideWithValue(localNotificationsPlugin),
       ],
       observers: [
         ProviderLogger(),

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -3,6 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../feature/debug/ui/debug_page.dart';
+import '../feature/debug/ui/debug_router_page.dart';
+import '../feature/debug/ui/registered_local_notification_index_page.dart';
 import '../feature/root/ui/root_router_page.dart';
 import '../feature/routine/data/routine.dart';
 import '../feature/routine/ui/current_routine_router_page.dart';
@@ -38,6 +41,7 @@ class AppRouter extends _$AppRouter {
           page: RootRouterRoute.page,
           children: [
             routineRouterRoute,
+            debugRouterRoute,
           ],
         ),
       ];
@@ -73,6 +77,21 @@ class AppRouter extends _$AppRouter {
                 page: RepetitionUpdateRoute.page,
               ),
             ],
+          ),
+        ],
+      );
+
+  AutoRoute get debugRouterRoute => AutoRoute(
+        path: 'debug',
+        page: DebugRouterRoute.page,
+        children: [
+          AutoRoute(
+            initial: true,
+            page: DebugRoute.page,
+          ),
+          AutoRoute(
+            path: 'registered-local-notification',
+            page: RegisteredLocalNotificationIndexRoute.page,
           ),
         ],
       );

--- a/lib/router/router.gr.dart
+++ b/lib/router/router.gr.dart
@@ -29,6 +29,24 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
+    DebugRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const DebugPage(),
+      );
+    },
+    DebugRouterRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const DebugRouterPage(),
+      );
+    },
+    RegisteredLocalNotificationIndexRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const RegisteredLocalNotificationIndexPage(),
+      );
+    },
     RepetitionAddRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
@@ -129,6 +147,48 @@ class CurrentRoutineRouterRouteArgs {
   String toString() {
     return 'CurrentRoutineRouterRouteArgs{key: $key, routineId: $routineId, cache: $cache}';
   }
+}
+
+/// generated route for
+/// [DebugPage]
+class DebugRoute extends PageRouteInfo<void> {
+  const DebugRoute({List<PageRouteInfo>? children})
+      : super(
+          DebugRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'DebugRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [DebugRouterPage]
+class DebugRouterRoute extends PageRouteInfo<void> {
+  const DebugRouterRoute({List<PageRouteInfo>? children})
+      : super(
+          DebugRouterRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'DebugRouterRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [RegisteredLocalNotificationIndexPage]
+class RegisteredLocalNotificationIndexRoute extends PageRouteInfo<void> {
+  const RegisteredLocalNotificationIndexRoute({List<PageRouteInfo>? children})
+      : super(
+          RegisteredLocalNotificationIndexRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'RegisteredLocalNotificationIndexRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
 }
 
 /// generated route for

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -249,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.10"
   fake_async:
     dependency: transitive
     description:
@@ -294,6 +302,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: c18f1de98fe0bb9dd5ba91e1330d4febc8b6a7de6aae3ffe475ef423723e72f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "16.3.2"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "33f741ef47b5f63cc7f78fe75eeeac7e19f171ff3c3df054d84c1e38bedb6a03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0+1"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "7cf643d6d5022f3baed0be777b0662cce5919c0a7b86e700299f22dc4ae660ef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0+1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -317,6 +349,19 @@ packages:
     version: "3.0.1"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: "06b35132c98fa188db3c4b654b7e1af7ccd01dfe12a004d58be423357605fb24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.8"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -805,6 +850,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  timezone:
+    dependency: "direct main"
+    description:
+      name: timezone
+      sha256: "1cfd8ddc2d1cfd836bc93e67b9be88c3adaeca6f40a00ca999104c30693cdca0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.2"
   timing:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -178,7 +178,7 @@ packages:
     source: hosted
     version: "4.10.0"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
@@ -438,7 +438,7 @@ packages:
     source: hosted
     version: "4.0.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,10 +11,12 @@ dependencies:
   cupertino_icons: ^1.0.6
   flutter:
     sdk: flutter
+  flutter_local_notifications: ^16.3.2
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: ^2.4.9
   flutter_slidable: ^3.0.1
+  flutter_timezone: ^1.0.8
   freezed_annotation: ^2.4.1
   gap: ^3.0.1
   isar: 3.1.0+1
@@ -25,6 +27,7 @@ dependencies:
   path_provider:
   riverpod_annotation: ^2.3.3
   roggle: ^0.4.2+1
+  timezone:
 
 dev_dependencies:
   auto_route_generator: ^7.3.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   auto_route: ^7.8.4
+  collection:
   cupertino_icons: ^1.0.6
   flutter:
     sdk: flutter
@@ -19,6 +20,7 @@ dependencies:
   flutter_timezone: ^1.0.8
   freezed_annotation: ^2.4.1
   gap: ^3.0.1
+  intl:
   isar: 3.1.0+1
   isar_flutter_libs: 3.1.0+1
   json_annotation: ^4.8.1


### PR DESCRIPTION
# 関連する Issue

- close #11

# やったこと

## バグ対応

- 一覧画面の分表示誤り
- ルーティン編集画面の時刻表示で繰り返し設定画面に遷移してしまっていた
 
## 通知機能の実装をしました。

- ルーティンの「プッシュ通知」を削除しました。
  - https://github.com/IkemotoNanako/repeat_notification_app/issues/11#issuecomment-1970650215 参照
- ルーティンに「ラベル」を追加しました。
  - https://github.com/IkemotoNanako/repeat_notification_app/issues/11#issuecomment-1970650215 参照
  - プッシュ通知時のメッセージを変更できます。
  - デフォルトは「アラーム」です。
- ルーティン登録時のデフォルト時間を 07:00 から現在時刻に変更しました。
- 起動時にプッシュ通知送信の許可を得るようにしました。
- 設定した時刻にプッシュ通知をする
  - 繰り返しに対応
  - サウンド通知の有無に対応
  - 無効の場合はプッシュ通知を送らない
- デバッグ機能として、実際に端末に登録されている通知一覧を表示する機能を実装しました。
  - ルーティン上部のスピナーアイコンからたどれます。

# やらないこと

- #15

# スクリーンショット

### iOS


https://github.com/IkemotoNanako/repeat_notification_app/assets/13707135/6b8eae1e-1577-417d-b7be-df69a4c63881


### Android

https://github.com/IkemotoNanako/repeat_notification_app/assets/13707135/a4cfb0fc-d821-48df-aba8-7288c6e05919



